### PR TITLE
Add Claude Code slash commands

### DIFF
--- a/.claude/commands/address-pr.md
+++ b/.claude/commands/address-pr.md
@@ -1,0 +1,30 @@
+---
+description: Address all open PR review comments on the current branch
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Grep, Glob
+---
+
+You are addressing open review comments on the current pull request.
+
+## Step 1 — Get the PR number for the current branch
+Run: `!git branch --show-current`
+Then find the PR: `!gh pr view --json number,title,url`
+
+## Step 2 — Fetch all review comments
+Use the actual repo from: `!gh repo view --json nameWithOwner --jq '.nameWithOwner'`
+And PR number from step 1.
+
+PR-level comments (where Claude posts summaries): `!gh api repos/{owner}/{repo}/issues/{pr_number}/comments --jq '.[] | {author: .user.login, body: .body}'`
+Inline code comments: `!gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[] | {path: .path, line: .line, body: .body, author: .user.login}'`
+Formal reviews: `!gh pr view --json reviews --jq '.reviews[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {author: .author.login, body: .body}'`
+
+## Step 3 — Analyse and address each comment
+For each comment:
+1. Read the referenced file and line if applicable
+2. Understand what change is being requested
+3. Make the change
+4. If a comment is a question or FYI (not requesting a code change), skip it
+
+## Step 4 — Summarise
+After addressing all comments, list:
+- What was changed and why
+- Any comments you skipped and why (e.g. question, already resolved, out of scope)

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,56 @@
+---
+description: Commit current changes and create a PR. Stages files, commits, pushes branch, and opens a PR.
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Glob
+---
+
+You are committing the current changes and creating a pull request for the Pitchd app.
+
+## Step 1 — Review current changes
+Run: `!git status`
+Run: `!git diff --stat`
+
+Identify what files have changed and understand what the changes are about.
+
+## Step 2 — Check current branch
+Run: `!git branch --show-current`
+
+If on `main`, stop and tell the user to switch to a feature branch first. Do not commit directly to main.
+
+## Step 3 — Stage and commit
+Stage relevant files (never stage .env, .env.local, or secrets):
+`!git add <files>`
+
+Write a concise commit message that describes what changed and why. Use the format:
+- `feat:` for new features
+- `fix:` for bug fixes
+- `chore:` for config, docs, tooling
+
+```
+git commit -m "$(cat <<'EOF'
+<type>: <short description>
+
+<optional longer explanation if needed>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+## Step 4 — Push branch
+`!git push -u origin <branch-name>`
+
+## Step 5 — Create PR
+```
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+<bullet points of what changed>
+
+## Notes
+<any decisions, trade-offs, or things to be aware of — omit if none>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL when done.

--- a/.claude/commands/wrap-up.md
+++ b/.claude/commands/wrap-up.md
@@ -1,0 +1,67 @@
+---
+description: End-of-session wrap-up. Updates docs with decisions made, closes completed issues, commits and raises a PR.
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Grep, Glob
+---
+
+You are wrapping up a Claude Code session for the Pitchd app. Your job is to make sure all context is captured and ready for the next session.
+
+## Step 1 — Review what happened this session
+Run: `!git log --oneline -20`
+Run: `!gh issue list --state closed --limit 20 --json number,title,closedAt | jq '.[] | select(.closedAt > (now - 86400 | todate))'` to find issues closed today.
+
+Also review the current conversation to identify:
+- Technical decisions made
+- Features implemented
+- Anything that changed from the plan
+
+## Step 2 — Update docs/project-context.md
+- Update **Current Phase** if the phase has changed
+- Add a new row to the **Session Log** table with today's date, current phase, and a concise summary of what was covered
+- Update **Next Actions** with what should be tackled next session
+- Mark any completed phases with ✅
+
+## Step 3 — Update docs/technical/technical-design.md
+Only update if technical decisions were made this session:
+- New or changed architecture decisions
+- Data model changes
+- API route changes
+- New milestones or milestone changes
+- Any TBD sections that are now resolved
+
+## Step 4 — Update CLAUDE.md
+Only update if something fundamental changed:
+- Current stage / phase
+- Tech stack decisions finalised
+- Milestone progress
+
+## Step 5 — Close completed GitHub issues
+For any work completed this session that has a corresponding GitHub issue, close it:
+`!gh issue close <number> --comment "Completed in this session."`
+
+## Step 6 — Commit and raise a PR
+Stage only doc files (never commit .env or secrets):
+```
+git add CLAUDE.md docs/ .claude/commands/
+git checkout -b chore/session-wrap-<YYYY-MM-DD>
+git commit -m "chore: session wrap-up <YYYY-MM-DD>"
+git push -u origin chore/session-wrap-<YYYY-MM-DD>
+```
+
+Then create a PR:
+```
+gh pr create --title "Session wrap-up <YYYY-MM-DD>" --body "$(cat <<'EOF'
+## Session summary
+<bullet points of what was covered>
+
+## Docs updated
+<list of files changed and why>
+
+## Issues closed
+<list of issues closed, or "none">
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL when done.


### PR DESCRIPTION
## Summary
- `/pr` — stages, commits, pushes and opens a PR from the current branch
- `/wrap-up` — end-of-session doc updates, closes completed issues, commits and raises a PR
- `address-pr` — addresses open PR review comments on the current branch

## Notes
Commands live in `.claude/commands/` and are available across devices since `.claude/` is now tracked in git.

🤖 Generated with [Claude Code](https://claude.com/claude-code)