### PR TITLE
Update Claude Code slash commands

### DIFF
--- a/.claude/commands/address-pr.md
+++ b/.claude/commands/address-pr.md
@@ -1,5 +1,5 @@
 ---
-description: Address all open PR review comments on the current branch
+description: Review open PR comments and present a table of issues with recommended actions, then wait for approval before implementing.
 allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Grep, Glob
 ---
 
@@ -17,14 +17,29 @@ PR-level comments (where Claude posts summaries): `!gh api repos/{owner}/{repo}/
 Inline code comments: `!gh api repos/{owner}/{repo}/pulls/{pr_number}/comments --jq '.[] | {path: .path, line: .line, body: .body, author: .user.login}'`
 Formal reviews: `!gh pr view --json reviews --jq '.reviews[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {author: .author.login, body: .body}'`
 
-## Step 3 — Analyse and address each comment
-For each comment:
-1. Read the referenced file and line if applicable
-2. Understand what change is being requested
-3. Make the change
-4. If a comment is a question or FYI (not requesting a code change), skip it
+## Step 3 — Present a review table
+Do NOT make any changes yet. Instead, analyse all comments and present a table:
 
-## Step 4 — Summarise
-After addressing all comments, list:
-- What was changed and why
-- Any comments you skipped and why (e.g. question, already resolved, out of scope)
+| # | File | Issue | Recommended Action | Priority |
+|---|---|---|---|---|
+| 1 | path/to/file.ts | Description of issue | What you plan to do | High / Medium / Low |
+
+Below the table, note any comments you plan to skip and why (e.g. question only, already resolved, out of scope).
+
+Then ask: **"Shall I go ahead and implement all of these?"**
+
+## Step 4 — Implement (only after user confirms)
+Once the user confirms, address each item in the table:
+1. Read the referenced file and line
+2. Make the change
+3. If a comment is a question or FYI (not requesting a code change), skip it
+
+## Step 5 — Commit and push
+Stage and commit the fixes:
+```
+git add <changed files>
+git commit -m "fix: address PR review comments"
+git push
+```
+
+Summarise what was changed and what was skipped.

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,5 +1,5 @@
 ---
-description: Implement a GitHub issue by number. Creates a branch, implements the work, and opens a PR.
+description: Implement a GitHub issue by number. Creates a branch, implements the work, verifies acceptance criteria, and opens a PR.
 allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Grep, Glob, Agent
 argument-hint: <issue-number>
 ---
@@ -9,7 +9,7 @@ You are implementing a GitHub issue for the Pitchd app.
 ## Step 1 — Fetch the issue
 Run: `!gh issue view $ARGUMENTS --json number,title,body,labels,milestone`
 
-Read the issue title, body, labels, and milestone carefully.
+Read the issue title, body, labels, milestone, and **acceptance criteria** carefully. The acceptance criteria are the definition of done — every item must be met before the PR is raised.
 
 ## Step 2 — Load context
 Always read these before writing any code:
@@ -38,7 +38,20 @@ Implement the issue following all conventions in CLAUDE.md:
 
 Keep the implementation focused on exactly what the issue describes. Do not add extra features or refactor unrelated code.
 
-## Step 5 — Open a PR
+## Step 5 — Verify acceptance criteria
+Go through each acceptance criteria item from the issue body one by one. For each item:
+1. Verify it is met by reading the relevant code, running a check, or confirming the behaviour
+2. If an item is not met, fix it before proceeding
+3. Once verified, tick it off on the GitHub issue by updating the issue body — replace `- [ ]` with `- [x]` for that item
+
+Update the issue body with all ticked items:
+```
+gh issue edit $ARGUMENTS --repo mrdlam87/pitchd-app --body "<full updated body with ticked checkboxes>"
+```
+
+Do not raise the PR until all acceptance criteria are ticked.
+
+## Step 6 — Open a PR
 Run: `!git add <relevant files> && git commit -m "<message>"`
 
 Then create a PR:

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,67 @@
+---
+description: Review and refine a GitHub issue's acceptance criteria and plan the implementation before building. Run this before /implement.
+allowed-tools: Bash(gh:*), Read, Glob, Grep
+argument-hint: <issue-number>
+---
+
+You are planning the implementation of a GitHub issue for the Pitchd app. Do NOT write any code yet.
+
+## Step 1 — Fetch the issue
+Run: `!gh issue view $ARGUMENTS --json number,title,body,labels,milestone`
+
+Read the issue title, body, labels, milestone, and existing acceptance criteria carefully.
+
+## Step 2 — Load context
+Always read these before planning:
+- `CLAUDE.md` — project overview, conventions, tech stack
+- `docs/technical/technical-design.md` — architecture, data models, API routes, milestones
+
+If the issue is UI-related, also check `prototypes/pitchd-light-v2.jsx` for the reference implementation.
+
+If the issue touches existing code, use Glob and Grep to find relevant files before planning.
+
+## Step 3 — Review acceptance criteria
+Evaluate the existing acceptance criteria and identify:
+- Any items that are missing or incomplete
+- Any items that are too vague to verify
+- Any items that are out of scope for this issue
+- Any items that depend on another issue not yet done
+
+## Step 4 — Draft implementation plan
+Outline exactly how you would implement this issue:
+- What files will be created
+- What files will be modified
+- Key decisions or trade-offs to be aware of
+- Any blockers or dependencies on other issues
+- Estimated complexity (simple / moderate / complex)
+
+## Step 5 — Present for review
+Present everything to the user in this format:
+
+---
+
+### Refined Acceptance Criteria
+Show the full updated checklist — unchanged items plus any additions, removals, or clarifications. Clearly mark changes with **(new)**, **(updated)**, or **(removed)**.
+
+### Implementation Plan
+| # | Action | File | Notes |
+|---|---|---|---|
+| 1 | Create / Edit / Delete | `path/to/file` | What and why |
+
+### Decisions needed
+List any ambiguous points that need the user's input before implementation starts.
+
+### Blockers
+List any other issues that must be completed first, or none.
+
+---
+
+Then ask: **"Shall I update the issue with these refined acceptance criteria?"**
+
+## Step 6 — Update the issue (only after user confirms)
+If the user confirms, update the issue body with the refined acceptance criteria:
+```
+gh issue edit $ARGUMENTS --repo mrdlam87/pitchd-app --body "<full updated body>"
+```
+
+Confirm the issue has been updated and that it's ready for `/implement`.


### PR DESCRIPTION
## Summary
- `/plan` (new) — reviews and refines issue acceptance criteria, produces an implementation plan, waits for confirmation before updating the issue
- `/implement` (updated) — now verifies each AC item after building and ticks it off on the GitHub issue before raising the PR
- `/address-pr` (updated) — now presents a table of review comments with recommended actions and waits for user confirmation before making any changes

## Workflow
```
/plan 14       ← refine AC, get implementation plan
/implement 14  ← build, verify AC, open PR
/address-pr    ← handle review comments
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)