### PR TITLE
Implement protected routes (beta/admin only)

### DIFF
--- a/app/app/access-denied/page.tsx
+++ b/app/app/access-denied/page.tsx
@@ -4,8 +4,9 @@ export default function AccessDeniedPage() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#f7f5f0]">
       <div className="flex flex-col items-center gap-6 text-center max-w-sm px-4">
-        <h1 className="font-[family-name:var(--font-lora)] text-4xl text-[#2d4a2d]">
-          Pitchd
+        <h1 className="font-[family-name:var(--font-lora)] text-4xl font-bold tracking-tight">
+          <span className="text-[#2d4a2d]">Pitch</span>
+          <span className="text-[#e8674a]">d</span>
         </h1>
         <div className="flex flex-col gap-2">
           <h2 className="text-xl font-semibold text-[#2d4a2d]">

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,8 +1,9 @@
 export default function Home() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#f7f5f0]">
-      <h1 className="font-[family-name:var(--font-lora)] text-4xl text-[#2d4a2d]">
-        Pitchd
+      <h1 className="font-[family-name:var(--font-lora)] text-4xl font-bold tracking-tight">
+        <span className="text-[#2d4a2d]">Pitch</span>
+        <span className="text-[#e8674a]">d</span>
       </h1>
     </main>
   );

--- a/app/app/sign-in/page.tsx
+++ b/app/app/sign-in/page.tsx
@@ -4,8 +4,9 @@ export default function SignInPage() {
   return (
     <main className="flex min-h-screen items-center justify-center bg-[#f7f5f0]">
       <div className="flex flex-col items-center gap-8">
-        <h1 className="font-[family-name:var(--font-lora)] text-4xl text-[#2d4a2d]">
-          Pitchd
+        <h1 className="font-[family-name:var(--font-lora)] text-4xl font-bold tracking-tight">
+          <span className="text-[#2d4a2d]">Pitch</span>
+          <span className="text-[#e8674a]">d</span>
         </h1>
         <p className="text-[#5a7a5a] text-center max-w-xs">
           AI-powered camping companion for Australian campers.
@@ -18,7 +19,8 @@ export default function SignInPage() {
         >
           <button
             type="submit"
-            className="flex items-center gap-3 rounded-full bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-md ring-1 ring-gray-200 hover:shadow-lg transition-shadow"
+            className="flex items-center gap-3 rounded-full bg-white px-6 py-3 text-sm font-semibold text-gray-700 shadow-md hover:shadow-lg transition-shadow"
+            style={{ border: "1.5px solid #e0dbd0" }}
           >
             <svg width="20" height="20" viewBox="0 0 48 48" aria-hidden="true">
               <path

--- a/app/auth.config.ts
+++ b/app/auth.config.ts
@@ -1,0 +1,15 @@
+import Google from "next-auth/providers/google";
+import type { NextAuthConfig } from "next-auth";
+
+// Edge-compatible config — no Prisma, no Node.js-only modules.
+// Used by middleware. Full auth.ts adds the Prisma callbacks on top.
+export const authConfig: NextAuthConfig = {
+  providers: [Google],
+  callbacks: {
+    async session({ session, token }) {
+      if (token.userId) session.user.id = token.userId as string;
+      if (token.role) session.user.role = token.role as string;
+      return session;
+    },
+  },
+};

--- a/app/middleware.ts
+++ b/app/middleware.ts
@@ -1,6 +1,8 @@
-import { auth } from "@/auth";
+import NextAuth from "next-auth";
 import { NextResponse } from "next/server";
-import { UserRole } from "@/lib/generated/prisma/enums";
+import { authConfig } from "@/auth.config";
+
+const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
   const { nextUrl, auth: session } = req;
@@ -20,7 +22,7 @@ export default auth((req) => {
   }
 
   // Authenticated but not invited — redirect to access-denied page
-  if (session.user.role === UserRole.user) {
+  if (session.user.role === "user") {
     return NextResponse.redirect(new URL("/access-denied", nextUrl.origin));
   }
 


### PR DESCRIPTION
Closes #16

## What
- Custom `/sign-in` page with a "Sign in with Google" button (server action via Auth.js)
- Custom `/access-denied` page with waitlist messaging for `role: "user"` accounts
- Middleware updated to redirect unauthenticated users to `/sign-in` and waitlisted users to `/access-denied` (previously returned a raw 403)

## Notes
- `/sign-in` and `/access-denied` are allowlisted in the middleware matcher so they render without auth loops
- Sign-out on the access-denied page redirects back to `/sign-in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)