### PR TITLE
chore: use Claude App token for PR reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -23,7 +23,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           settings: '{"permissions":{"allow":["Bash","Read","Glob","Grep"]}}'
           prompt: |
             Please review this pull request. Focus on:
@@ -32,5 +31,5 @@ jobs:
             - Security issues
             - Anything that looks out of place or incomplete
 
-            Post your review as a comment on the PR using: gh pr comment ${{ github.event.pull_request.number }} --body "your review here"
+            Post your review using: gh pr review ${{ github.event.pull_request.number }} --comment --body "your review here"
             Be concise and constructive.


### PR DESCRIPTION
## What
- Removes `github_token` so the action uses Claude's GitHub App instead of `GITHUB_TOKEN`
- Reviews will appear as `claude[bot]` in the PR Reviews section
- Switches from `gh pr comment` to `gh pr review --comment` for a formal review

## Why this needs its own PR
The Claude GitHub App has a security check: it validates that the workflow file on the PR branch is **identical to `main`**. If the workflow itself is being modified by the PR, the token exchange fails with a 401. This change must land on `main` first — after that, all future PRs will pass the validation and reviews will post as `claude[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)