### PR TITLE
chore: improve /implement command

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,10 +1,10 @@
 ---
 description: Implement a GitHub issue by number. Creates a branch, implements the work, verifies acceptance criteria, and opens a PR.
-allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Grep, Glob, Agent
+allowed-tools: Bash(git:*), Bash(gh:*), Read, Edit, Write, Grep, Glob, Agent, TodoWrite
 argument-hint: <issue-number>
 ---
 
-You are implementing a GitHub issue for the Pitchd app.
+You are a **software architect** implementing a GitHub issue for the Pitchd app. Spend the first third of your effort reading and planning — do not write code until you have a clear picture of what exists and what needs to change.
 
 ## Step 1 — Fetch the issue
 Run: `!gh issue view $ARGUMENTS --json number,title,body,labels,milestone`
@@ -18,13 +18,53 @@ Always read these before writing any code:
 
 If the issue is UI-related, also check `prototypes/pitchd-light-v2.jsx` for the reference implementation and design patterns to match.
 
-## Step 3 — Create a branch
+## Step 3 — Assess complexity
+Classify the issue before doing anything else:
+
+| Tier | Criteria |
+|---|---|
+| **Simple** | 1–2 files, clear scope, no DB/auth/concurrency changes |
+| **Medium** | 3–5 files, moderate scope, touches DB schema or API routes |
+| **Complex** | 6+ files, architectural impact, concurrency/transactions/auth |
+
+State the tier and what it means for this task. Complex issues get extra adversarial review attention in Step 9.
+
+**Checkpoint:** State the tier and a one-line reason before proceeding.
+
+## Step 4 — Explore & plan
+Before writing a single line, use Grep and Glob to find every file relevant to the issue — existing routes, models, components, scripts, migrations, or utilities that the implementation will touch or depend on.
+
+**Rule: never assume code exists.** Grep to confirm every function, method, field, model, or constant you plan to reference actually exists before using it. Hallucinated references are a top source of bugs.
+
+Read any files you'll be modifying.
+
+Then present a plan to the user:
+
+---
+### Plan
+| # | Action | File | Notes |
+|---|---|---|---|
+| 1 | Create / Edit / Delete | `path/to/file` | What and why |
+
+**Risks / unknowns:** anything ambiguous, potentially breaking, or worth flagging upfront.
+
+---
+
+Ask: **"Does this look right? I'll create the branch and start once you confirm."**
+
+Wait for confirmation before proceeding.
+
+**Checkpoint:** Plan table presented and confirmed by the user.
+
+## Step 5 — Create a branch
 Branch naming: `feature/`, `fix/`, or `chore/` prefix based on issue type, followed by issue number and a short slug.
 Example: `feature/13-scaffold-nextjs-app`
 
 Run: `!git checkout -b <branch-name>`
 
-## Step 4 — Implement
+## Step 6 — Implement
+For Medium or Complex issues, use `TodoWrite` to track progress — one task per file or logical unit of work. Mark each done as you go.
+
 Implement the issue following all conventions in CLAUDE.md:
 - TypeScript throughout
 - Tailwind utility classes only — no custom CSS
@@ -38,20 +78,22 @@ Implement the issue following all conventions in CLAUDE.md:
 
 Keep the implementation focused on exactly what the issue describes. Do not add extra features or refactor unrelated code.
 
-## Step 5 — Verify acceptance criteria
+**Checkpoint:** All planned files created or modified. TodoWrite tasks marked done.
+
+## Step 7 — Verify acceptance criteria
 Go through each acceptance criteria item from the issue body one by one. For each item:
 1. Verify it is met by reading the relevant code, running a check, or confirming the behaviour
 2. If an item is not met, fix it before proceeding
-3. Once verified, tick it off on the GitHub issue by updating the issue body — replace `- [ ]` with `- [x]` for that item
+3. Once verified, tick it off on the GitHub issue — replace `- [ ]` with `- [x]` for that item
 
-Update the issue body with all ticked items:
+Update the issue body:
 ```
 gh issue edit $ARGUMENTS --repo mrdlam87/pitchd-app --body "<full updated body with ticked checkboxes>"
 ```
 
 Do not raise the PR until all acceptance criteria are ticked.
 
-## Step 6 — Build & smoke test
+## Step 8 — Build & smoke test
 Run these checks before opening the PR. Fix any errors before proceeding.
 
 **Always run:**
@@ -79,23 +121,70 @@ cd app && npx prisma migrate status
 
 Report the results of each check. If a check fails, fix it before proceeding.
 
-## Step 7 — Open a PR
-Run: `!git add <relevant files> && git commit -m "<message>"`
+## Step 9 — Pre-PR self-review
+Re-read every file you changed. Answer each question below out loud before marking it done. Fix anything you find.
+
+**Adversarial questions:**
+- What happens if this runs twice concurrently?
+- What if any of these fields are null, zero, empty string, or negative?
+- What assumptions am I making that could be wrong in production?
+- If I were trying to break this, how would I do it?
+
+**Named patterns to check for:**
+- **TOCTOU** — if you read state and then act on it without an atomic lock, that's a race condition. Any read-then-write on shared DB rows or files needs an atomic check-and-act.
+- **Transaction side-effects** — records created inside a DB transaction are rolled back if the transaction throws. Error logs, audit records, and notifications must be written *outside* the transaction.
+
+**Lifecycle checklist:**
+- [ ] Edge cases & failure modes covered
+- [ ] Operational concerns addressed (timeouts, concurrency, failure notifications for scheduled jobs)
+- [ ] Data integrity — full lifecycle handled (insert, update, *and* stale/removed records)
+- [ ] Resource cleanup — DB connections and file handles closed on error paths (`.finally(() => prisma.$disconnect())`)
+- [ ] Scope matches intent of the issue, not just its literal acceptance criteria
+
+For **Complex** issues, spend extra time on the adversarial questions and TOCTOU/transaction checks.
+
+Do not open the PR until all items are addressed.
+
+## Step 10 — Open a PR
+Commit using conventional commit format:
+```
+git commit -m "type(scope): short description"
+```
+Types: `feat`, `fix`, `chore`, `refactor`, `docs`. Scope is optional but useful (e.g. `feat(auth)`, `fix(osm-sync)`).
+
+Stage only files relevant to the issue — do not use `git add -A`.
 
 Then create a PR:
 ```
-gh pr create --title "<issue title>" --body "$(cat <<'EOF'
+gh pr create --base main --title "<issue title>" --body "$(cat <<'EOF'
 Closes #<issue-number>
 
 ## What
 <1-3 bullet points describing what was implemented>
 
+## Self-review
+- [x] Adversarial questions answered (concurrency, nulls, assumptions, break attempts)
+- [x] TOCTOU and transaction side-effects checked
+- [x] Data integrity — full lifecycle handled
+- [x] Resource cleanup — connections/handles closed on error paths
+- [x] Scope matches intent of the issue
+
 ## Notes
-<Any decisions made, trade-offs, or things to be aware of>
+<Any decisions made, trade-offs, or things the reviewer should know>
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```
 
-Return the PR URL when done.
+Return the PR URL.
+
+## Step 11 — Monitor CI
+After the PR is opened, wait for the Claude code review to post its findings.
+
+When the review appears:
+1. Read every finding — do not skip low-severity items
+2. For each finding: either fix it and push a follow-up commit, or reply explaining why it's a false positive
+3. Never declare the PR ready while CI is still pending or findings are unaddressed
+
+Use `gh pr checks <pr-number>` to monitor status. Use `gh pr view <pr-number> --comments` to read review output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,16 @@ PitchdLight          ← root, owns all state (screen, results, searchState, etc
 - Branch naming: `feature/`, `chore/`, `fix/` prefixes
 - Claude PR review available on-demand: comment `@claude` on any PR
 - CI: `.github/workflows/claude-review.yml`
+
+---
+
+## Pre-PR self-review
+
+Before opening a PR, re-read every file you changed and ask:
+
+- **Edge cases & failure modes** — are there states not handled? (e.g. records that should be cleaned up, missing null checks, partial failure mid-batch)
+- **Operational concerns** — are there missing timeouts, no guard against concurrent runs, unbounded loops, or silent failure paths?
+- **Data integrity** — does the implementation handle the full lifecycle? (e.g. not just inserting/updating, but also marking stale or removed records)
+- **Scope completeness** — does the implementation match the *intent* of the issue, or just its literal acceptance criteria?
+
+Fix any issues found before raising the PR.


### PR DESCRIPTION
## Summary
- Add complexity tier assessment (simple/medium/complex) before branching to scale planning and review effort
- Add explore & plan step with codebase verification rule ("never assume code exists — grep first") and user confirmation gate before any code is written
- Add adversarial self-review (concurrency, nulls, TOCTOU, transaction side-effects) replacing the checkbox-only approach
- Add CI monitoring loop as a final step — read every finding, fix or respond, never close while pending
- Fix self-review checklist in PR body to show `[x]` (review already happened before this step)
- Add conventional commit format guidance and `--base main` to PR creation
- Add Pre-PR self-review section to CLAUDE.md

## Notes
Inspired by https://github.com/vlad-ko/claude-wizard — specifically the architect mindset framing, codebase-verification discipline, adversarial questions, and Bug Bot monitoring loop pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)