### PR TITLE
chore: update CLAUDE.md and implement command with session learnings

### DIFF
--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -109,6 +109,14 @@ cd app && npx prisma generate
 cd app && npx prisma migrate status
 ```
 
+**If the issue adds or modifies an API route:**
+- Write or update tests in `tests/api/<route>.test.ts` covering the new/changed behaviour before opening the PR
+- Use the API route checklist from Step 9 to drive test cases — every validation rule should have a corresponding test
+```bash
+cd app && npm test
+```
+All tests must pass before opening the PR.
+
 **Issue-type smoke tests** — run the most relevant check(s) for the issue:
 | Issue type | Manual check |
 |---|---|
@@ -142,6 +150,16 @@ Re-read every file you changed. Answer each question below out loud before marki
 - [ ] Scope matches intent of the issue, not just its literal acceptance criteria
 
 For **Complex** issues, spend extra time on the adversarial questions and TOCTOU/transaction checks.
+
+**If the issue is an API route, also check:**
+- [ ] All query params validated: missing (null), empty string, non-numeric, and out-of-range values
+- [ ] Use `Number()` not `parseFloat()` — `parseFloat("123abc")` silently returns `123`; `Number("123abc")` returns `NaN`. Use `|| NaN` to handle null/empty: `Number(param || NaN)`
+- [ ] `try/catch` wraps all DB calls; catch block logs with `console.error` before returning 500
+- [ ] `orderBy` includes a unique tiebreaker (e.g. `{ id: "asc" }`) for stable pagination across pages
+- [ ] Columns used in `where` filters have indexes in `schema.prisma`
+- [ ] Paginated responses include metadata: `page`, `pageSize`, `hasMore`
+- [ ] Array params use `.filter(Boolean)` to drop empty string values (e.g. `?amenities=`)
+- [ ] Return type annotation on the handler: `Promise<Response>`
 
 Do not open the PR until all items are addressed.
 
@@ -178,13 +196,3 @@ EOF
 ```
 
 Return the PR URL.
-
-## Step 11 — Monitor CI
-After the PR is opened, wait for the Claude code review to post its findings.
-
-When the review appears:
-1. Read every finding — do not skip low-severity items
-2. For each finding: either fix it and push a follow-up commit, or reply explaining why it's a false positive
-3. Never declare the PR ready while CI is still pending or findings are unaddressed
-
-Use `gh pr checks <pr-number>` to monitor status. Use `gh pr view <pr-number> --comments` to read review output.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Core differentiator:** Natural language search with live weather-awareness.
 **Target market:** Australian campers (primary), architecture should allow future expansion.
-**Current stage:** Phase 5 — M1 complete. App live at https://pitchd-app.vercel.app. Starting M2 (campsite data pipeline).
+**Current stage:** Phase 5 — M3 in progress. M1 (foundation) and M2 (campsite pipeline, DB seeded) complete. App live at https://pitchd-app.vercel.app.
 **GitHub:** github.com/mrdlam87/pitchd-app
 
 ---
@@ -75,7 +75,7 @@ PitchdLight          ← root, owns all state (screen, results, searchState, etc
 | Weather | Open-Meteo (free, no API key) |
 | Database | PostgreSQL via Prisma ORM |
 | Hosted DB | Supabase |
-| Map | Mapbox (tentative — confirm at Phase 5 start) |
+| Map | Mapbox |
 | Deployment | Vercel |
 
 ### Conventions
@@ -97,6 +97,18 @@ PitchdLight          ← root, owns all state (screen, results, searchState, etc
   - Coral (CTA / accent): `#e8674a`
   - Warm border: `1.5px solid #e0dbd0`
   - Wordmark: "Pitch" in forest green + "d" in coral, Lora serif, bold
+
+### Testing
+- Integration tests live in `app/tests/api/<route>.test.ts` — run with `npm test`
+- Auth is mocked: `vi.mock("@/auth")` + cast `auth as () => Promise<Session | null>` to avoid middleware overload
+- Seed test records with `source: "test"` — cleaned up in `afterEach` via `prisma.X.deleteMany({ where: { source: "test" } })`
+- Prefix seeded record names with `"!"` so they sort first alphabetically (guaranteed on page 1)
+- `tests/global-setup.ts` loads `.env.local` before Prisma singleton initialises — required for local test runs
+- Custom `Session` type in `types/next-auth.d.ts` requires `role: UserRole` in the user object
+
+### Data notes
+- `CampsiteAmenity` join table is empty — campsites have no linked amenities until M4
+- Amenity filter uses standard query param style: `?amenities=toilet&amenities=bbq` (not PHP-style `amenities[]`)
 
 ### Auth
 - Google OAuth only — no passwords stored


### PR DESCRIPTION
## What
- CLAUDE.md: update current stage to M3 in progress (M2 complete)
- CLAUDE.md: confirm Mapbox (remove "tentative")
- CLAUDE.md: add Testing section with Vitest patterns, auth mock approach, seed cleanup conventions
- CLAUDE.md: add Data notes (CampsiteAmenity empty until M4, amenity filter convention)
- implement.md: restore API route test requirement in Step 8
- implement.md: restore API route checklist in Step 9 (8 validation/quality items)
- implement.md: remove Step 11 CI monitoring (handled manually via /address-pr)

🤖 Generated with [Claude Code](https://claude.com/claude-code)