### PR TITLE
Get and display user device location

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -128,8 +128,21 @@ export default function MapView() {
   }, []);
 
   const handleLoad = useCallback(
-    (e: { target: mapboxgl.Map }) => loadCampsites(e.target),
-    [loadCampsites]
+    (_e: { target: mapboxgl.Map }) => {
+      // If geolocation resolved before the map finished loading, fly there now.
+      // onMoveEnd will handle the campsite load after the fly completes.
+      // Otherwise load campsites at the default viewport immediately.
+      if (userLocation) {
+        mapRef.current?.flyTo({
+          center: [userLocation.lng, userLocation.lat],
+          zoom: 11,
+          duration: 1200,
+        });
+      } else {
+        loadCampsites(_e.target);
+      }
+    },
+    [loadCampsites, userLocation]
   );
 
   const handleMoveEnd = useCallback(


### PR DESCRIPTION
Closes #26

## What
- Changed default fallback viewport from centre-of-Australia to Sydney (zoom 10)
- Added `useEffect` on `userLocation`: calls `flyTo` when geolocation resolves, which triggers `onMoveEnd` to reload campsites at the user's coordinates
- Location dot pin (coral circle) was already implemented in the base branch

## Self-review
- [x] Adversarial questions answered (concurrency, nulls, assumptions, break attempts)
- [x] TOCTOU and transaction side-effects checked
- [x] Data integrity — full lifecycle handled
- [x] Resource cleanup — connections/handles closed on error paths
- [x] Scope matches intent of the issue

## Notes
- `mapRef.current` is guarded with optional chaining in the `flyTo` effect — handles the rare case where geolocation resolves before the map finishes loading (geo is typically slower than map init)
- Campsites API already uses map centre, so flying to user location naturally satisfies "location passed to `/api/campsites`"

🤖 Generated with [Claude Code](https://claude.com/claude-code)