### PR TITLE
Build filter panel UI

### DIFF
--- a/app/components/FilterPanel.tsx
+++ b/app/components/FilterPanel.tsx
@@ -114,7 +114,7 @@ export default function FilterPanel({
     >
       {/* Header */}
       <div
-        className="flex-shrink-0 flex items-center justify-between px-4 pt-12 pb-3"
+        className="flex-shrink-0 flex items-center justify-between px-4 pb-3 pt-[max(3rem,env(safe-area-inset-top))]"
         style={{ borderBottom: `1px solid ${BORDER}`, background: "#fff" }}
       >
         <span

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -244,6 +244,10 @@ export default function MapView() {
   const handleApplyFilters = useCallback(
     (filters: FilterState) => {
       setActiveFilters(filters);
+      // Write ref directly here in addition to the useEffect sync — the useEffect
+      // fires after render, which is too late for the synchronous loadCampsites
+      // call below. Without this, the first search after applying filters would
+      // still use the previous filter values.
       activeFiltersRef.current = filters;
       setShowFilters(false);
       // Re-run the search immediately with the new filters applied

--- a/app/lib/tokens.ts
+++ b/app/lib/tokens.ts
@@ -2,9 +2,9 @@
 // Keep in sync with prototypes/pitchd-light-v2.jsx (C object).
 
 export const CORAL = "#e8674a";
-export const CORAL_LIGHT = "rgba(232,103,74,0.08)";
+export const CORAL_LIGHT = "#fdf0ed";
 export const FOREST_GREEN = "#2d4a2d";
 export const SAGE = "#5a7a5a";
 export const SURFACE = "#f7f5f0";
 export const BORDER = "#e0dbd0";
-export const TEXT_MUTED = "#7a9a7a";
+export const TEXT_MUTED = "#8a9e8a";


### PR DESCRIPTION
Closes #28

## What
- New `FilterPanel` component: full-screen overlay with Activities (Dog friendly, Fishing, Hiking, Swimming) and POIs (Dump points, Water fill, Laundromat, Toilets) as toggleable chips
- Floating Filters button on the map (top-right) with active filter count badge
- Active filters passed as `?amenities=` params to `/api/campsites` on apply; panel can be dismissed without changing filters

## Self-review
- [x] Adversarial questions answered (concurrency, nulls, assumptions, break attempts)
- [x] TOCTOU and transaction side-effects checked
- [x] Data integrity — full lifecycle handled
- [x] Resource cleanup — connections/handles closed on error paths
- [x] Scope matches intent of the issue

## Notes
- Amenity keys (`dog_friendly`, `fishing`, `hiking`, `swimming`, `dump_point`, `water_fill`, `laundromat`, `toilet`) match the expected `AmenityType.key` values to be seeded in M4 — filters work structurally now; results will appear once data is seeded
- `activeFiltersRef` mirrors state so the stable `loadCampsites` callback always reads the latest filters without needing them as a dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)