### PR TITLE
fix: eliminate map camera shift when drawer opens or pin clicked

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -86,7 +86,8 @@ const PEEK_HEIGHT = 64;
 // typically < 60px and acceptable for MVP.
 const drawerOpenPx = (): number => Math.round(window.innerHeight * 0.4);
 
-// Must match the Tailwind `transition-transform duration-300` on the drawer div.
+// Must match the inline `transition: transform ${DRAWER_TRANSITION_MS}ms ease-in-out`
+// style on the drawer div.
 const DRAWER_TRANSITION_MS = 300;
 
 const EMPTY_FILTERS: FilterState = { activities: [], pois: [] };
@@ -124,6 +125,9 @@ export default function MapView() {
   // Mirrors the selected campsite's ID so loadCampsites (stable callback) can
   // re-resolve the selection index after a fetch without needing selectedIdx as a dep.
   const selectedIdRef = useRef<string | null>(null);
+  // Tracks the deferred scrollIntoView timeout so rapid pin clicks cancel the
+  // previous pending scroll, and so it can be cleaned up on unmount.
+  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Request user geolocation on mount
   useEffect(() => {
@@ -191,6 +195,13 @@ export default function MapView() {
     drawerOpenRef.current = drawerOpen;
   }, [drawerOpen]);
 
+  // Clear any pending deferred scroll on unmount to avoid a setState-after-unmount warning.
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current !== null) clearTimeout(scrollTimeoutRef.current);
+    };
+  }, []);
+
   useEffect(() => {
     activeFiltersRef.current = activeFilters;
   }, [activeFilters]);
@@ -236,12 +247,12 @@ export default function MapView() {
   );
 
   const selectPin = useCallback(
-    (i: number, fly = true) => {
+    (i: number, animate = true) => {
       setDrawerOpen(true);
       setSelectedIdx(i);
       const campsite = campsites[i];
       selectedIdRef.current = campsite?.id ?? null;
-      if (fly && campsite && mapRef.current) {
+      if (animate && campsite && mapRef.current) {
         // Known edge case: a manual pan that starts during the 300ms easeTo animation
         // will have its moveend consumed by this flag (no refetch fires for that gesture).
         // Low-frequency and acceptable for MVP.
@@ -252,7 +263,7 @@ export default function MapView() {
           padding: { top: 0, right: 0, bottom: drawerOpenPx(), left: 0 },
         });
       }
-      if (fly) {
+      if (animate) {
         // Card click — drawer is already open, scroll immediately
         requestAnimationFrame(() => {
           cardRefs.current[i]?.scrollIntoView({
@@ -261,10 +272,12 @@ export default function MapView() {
           });
         });
       } else {
-        // Pin click — drawer is animating open (300ms). Delaying scrollIntoView
-        // until after the transition prevents the browser from trying to scroll
-        // the card into view mid-animation, which was causing the map to shift.
-        setTimeout(() => {
+        // Pin click — drawer is animating open. Delaying scrollIntoView until
+        // after the transition prevents a mid-animation scroll from shifting the
+        // map. Cancel any pending scroll from a previous rapid pin click first.
+        if (scrollTimeoutRef.current !== null) clearTimeout(scrollTimeoutRef.current);
+        scrollTimeoutRef.current = setTimeout(() => {
+          scrollTimeoutRef.current = null;
           cardRefs.current[i]?.scrollIntoView({
             behavior: "smooth",
             block: "nearest",


### PR DESCRIPTION
## Summary
- Pin clicks no longer move the map camera (`fly=false`); the drawer opens and the map stays put. Card clicks still ease-to centre the pin above the drawer.
- `scrollIntoView` on pin click is deferred by `DRAWER_TRANSITION_MS` (300 ms) until after the drawer CSS transition completes, preventing a mid-animation scroll from shifting the map. The timeout and the drawer's inline `transition` style both reference the same constant so they can't drift.
- On load without user location, `setPadding` initialises the Mapbox camera padding to `drawerOpenPx()` so the first card click never animates a `0→40vh` padding change simultaneously with the drawer opening (the original source of the double-focus bounce). `skipNextFetch` is set before `setPadding` to suppress the redundant `moveend`-triggered fetch it would otherwise fire.
- `overflow: hidden` scoped to the map container (`Map.tsx`) rather than `html, body` in `globals.css`, so future scrollable pages are unaffected.
- Selecting a campsite and then panning the map now preserves the selection if the campsite is still in the refreshed result set. The selected campsite ID is tracked in `selectedIdRef` (a stable ref readable by the `loadCampsites` callback) and re-resolved to its new index after each fetch.

## Test plan
- [ ] Click a campsite pin while drawer is collapsed → drawer opens, map does not move
- [ ] Click a card in the drawer → map eases to centre the pin above the drawer
- [ ] Click peek strip to re-open drawer → map does not move
- [ ] No browser scrollbar visible on the map page
- [ ] All behaviour unchanged when user location is granted
- [ ] Select a campsite, pan the map — selection is preserved if the pin is still in the visible area; clears if the pin has scrolled off-map

🤖 Generated with [Claude Code](https://claude.com/claude-code)