### PR TITLE
feat(map): loading states for initial load and pan/zoom refetches (#45)

### DIFF
--- a/app/components/BottomDrawer.tsx
+++ b/app/components/BottomDrawer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Drawer } from "vaul";
-import { CORAL, CORAL_LIGHT, FOREST_GREEN, SAGE, SURFACE } from "@/lib/tokens";
+import { BORDER, CORAL, CORAL_LIGHT, FOREST_GREEN, SAGE, SURFACE } from "@/lib/tokens";
 import { wmoCodeToEmoji, condColorForCode } from "@/lib/weatherScore";
 import type { AmenityPOI, Campsite, POIMeta, WeatherDay } from "@/types/map";
 import { haversineKm } from "@/lib/distance";
@@ -480,6 +480,7 @@ type Props = {
   drawerState: DrawerState;
   onDrawerStateChange: (state: DrawerState) => void;
   onSelectPin: (i: number) => void;
+  isFetching?: boolean;
 };
 
 export default function BottomDrawer({
@@ -494,6 +495,7 @@ export default function BottomDrawer({
   drawerState,
   onDrawerStateChange,
   onSelectPin,
+  isFetching = false,
 }: Props) {
   const isFull = drawerState === "full";
 
@@ -584,12 +586,23 @@ export default function BottomDrawer({
 
             {/* Summary row */}
             <div className="px-4 pb-2 flex items-center justify-between">
-              <div className="text-sm font-semibold" style={{ color: FOREST_GREEN }}>
-                {resultLabel}
-                {campsites.length > 0 && (
-                  <span className="ml-1.5 font-normal text-xs" style={{ color: SAGE }}>
-                    · nearby
-                  </span>
+              <div className="flex items-center gap-2">
+                <span
+                  className={`text-sm font-semibold transition-opacity${isFetching ? " animate-pulse" : ""}`}
+                  style={{ color: FOREST_GREEN }}
+                >
+                  {resultLabel}
+                  {campsites.length > 0 && (
+                    <span className="ml-1.5 font-normal text-xs" style={{ color: SAGE }}>
+                      · nearby
+                    </span>
+                  )}
+                </span>
+                {isFetching && (
+                  <div
+                    className="w-4 h-4 rounded-full animate-spin flex-shrink-0"
+                    style={{ border: `2px solid ${BORDER}`, borderTopColor: CORAL }}
+                  />
                 )}
               </div>
               {/* More / Less button — tap to cycle up, or collapse from full */}

--- a/app/components/BottomDrawer.tsx
+++ b/app/components/BottomDrawer.tsx
@@ -508,7 +508,7 @@ export default function BottomDrawer({
         : `${campsites.length} campsite${campsites.length === 1 ? "" : "s"} found`
       : selectedPoi
       ? (poiMeta[selectedPoi.amenityType.key] ?? { label: "POI" }).label
-      : "";
+      : "0 campsites found";
 
   // Peek state: show selected card (or first card) without scrolling
   const peekIdx = selectedIdx ?? 0;

--- a/app/components/BottomDrawer.tsx
+++ b/app/components/BottomDrawer.tsx
@@ -519,11 +519,13 @@ export default function BottomDrawer({
     ? (poiMeta[selectedPoi.amenityType.key] ?? { emoji: "📍", label: selectedPoi.amenityType.key, color: FOREST_GREEN })
     : null;
 
+  const hasContent = campsites.length > 0 || selectedPoi !== null;
+
   return (
     <Drawer.Root
-      snapPoints={SNAP_POINTS}
-      activeSnapPoint={snapForState(drawerState)}
-      setActiveSnapPoint={(snap) => onDrawerStateChange(stateForSnap(snap))}
+      snapPoints={hasContent ? SNAP_POINTS : [SNAP_POINTS[0]]}
+      activeSnapPoint={hasContent ? snapForState(drawerState) : SNAP_POINTS[0]}
+      setActiveSnapPoint={(snap) => { if (hasContent) onDrawerStateChange(stateForSnap(snap)); }}
       // modal=false: the map and UI above the drawer stay fully interactive.
       modal={false}
       // dismissible=false: peek is the minimum — the drawer never disappears.
@@ -605,18 +607,20 @@ export default function BottomDrawer({
                   />
                 )}
               </div>
-              {/* More / Less button — tap to cycle up, or collapse from full */}
-              <button
-                type="button"
-                className="text-[11px] font-bold flex-shrink-0 ml-2"
-                style={{ color: CORAL }}
-                onClick={() =>
-                  onDrawerStateChange(drawerState === "full" ? "peek" : cycleUp(drawerState))
-                }
-                aria-label={drawerState === "full" ? "Collapse drawer" : "Expand drawer"}
-              >
-                {drawerState === "full" ? "▼ Less" : "▲ More"}
-              </button>
+              {/* More / Less button — hidden when there's no content to expand into */}
+              {hasContent && (
+                <button
+                  type="button"
+                  className="text-[11px] font-bold flex-shrink-0 ml-2"
+                  style={{ color: CORAL }}
+                  onClick={() =>
+                    onDrawerStateChange(drawerState === "full" ? "peek" : cycleUp(drawerState))
+                  }
+                  aria-label={drawerState === "full" ? "Collapse drawer" : "Expand drawer"}
+                >
+                  {drawerState === "full" ? "▼ Less" : "▲ More"}
+                </button>
+              )}
             </div>
           </div>
 

--- a/app/components/BottomDrawer.tsx
+++ b/app/components/BottomDrawer.tsx
@@ -447,6 +447,7 @@ function DrawerContentList({
 // Vaul snap points: least → most visible.
 // "64px" = peek strip, HALF_VH = half viewport, 1 = full viewport.
 const SNAP_POINTS: (number | string)[] = ["64px", HALF_VH, 1];
+const PEEK_ONLY_SNAP_POINTS: (number | string)[] = [SNAP_POINTS[0]];
 
 function snapForState(s: DrawerState): number | string {
   if (s === "full") return 1;
@@ -523,7 +524,7 @@ export default function BottomDrawer({
 
   return (
     <Drawer.Root
-      snapPoints={hasContent ? SNAP_POINTS : [SNAP_POINTS[0]]}
+      snapPoints={hasContent ? SNAP_POINTS : PEEK_ONLY_SNAP_POINTS}
       activeSnapPoint={hasContent ? snapForState(drawerState) : SNAP_POINTS[0]}
       setActiveSnapPoint={(snap) => { if (hasContent) onDrawerStateChange(stateForSnap(snap)); }}
       // modal=false: the map and UI above the drawer stay fully interactive.
@@ -590,7 +591,7 @@ export default function BottomDrawer({
             <div className="px-4 pb-2 flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <span
-                  className={`text-sm font-semibold transition-opacity${isFetching ? " animate-pulse" : ""}`}
+                  className={`text-sm font-semibold${isFetching ? " animate-pulse" : ""}`}
                   style={{ color: FOREST_GREEN }}
                 >
                   {resultLabel}

--- a/app/components/BottomDrawer.tsx
+++ b/app/components/BottomDrawer.tsx
@@ -511,6 +511,8 @@ export default function BottomDrawer({
         : `${campsites.length} campsite${campsites.length === 1 ? "" : "s"} found`
       : selectedPoi
       ? (poiMeta[selectedPoi.amenityType.key] ?? { label: "POI" }).label
+      : isFetching
+      ? "Finding campsites…"
       : "0 campsites found";
 
   // Peek state: show selected card (or first card) without scrolling

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -216,6 +216,7 @@ export default function MapView() {
     hasMore,
     amenityPois,
     isInitialLoading,
+    isFetching,
     weatherCacheRef,
     loadCampsites,
     loadAmenities,
@@ -996,7 +997,7 @@ export default function MapView() {
           />
           <div className="text-center">
             <p className="font-serif text-base font-bold mb-1" style={{ color: FOREST_GREEN }}>
-              Finding the best spots…
+              Pitching the best spots…
             </p>
             <p className="text-xs" style={{ color: SAGE }}>
               Loading campsites nearby
@@ -1019,6 +1020,7 @@ export default function MapView() {
           drawerState={drawerState}
           onDrawerStateChange={handleDrawerStateChange}
           onSelectPin={selectPin}
+          isFetching={isFetching}
         />
       )}
     </div>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -759,7 +759,6 @@ export default function MapView() {
   // Fix when campsite/amenity linkage lands and the two filter surfaces are separated.
   const filterCount = activeFilters.activities.length + activeFilters.pois.length;
 
-  const showDrawer = campsites.length > 0 || selectedPoiId !== null;
 
   return (
     <div className="relative h-full w-full overflow-hidden">
@@ -1006,9 +1005,8 @@ export default function MapView() {
         </div>
       )}
 
-      {/* Bottom drawer — z-50 must exceed marker z-index (max 10) */}
-      {showDrawer && (
-        <BottomDrawer
+      {/* Bottom drawer — always rendered; shows ghost "0 campsites found" during initial load */}
+      <BottomDrawer
           campsites={campsites}
           hasMore={hasMore}
           amenityPois={amenityPois}
@@ -1022,7 +1020,6 @@ export default function MapView() {
           onSelectPin={selectPin}
           isFetching={isFetching}
         />
-      )}
     </div>
   );
 }

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -13,7 +13,7 @@ import BottomDrawer, {
   getDrawerHeightPx,
 } from "./BottomDrawer";
 import type { AmenityPOI, Campsite } from "@/types/map";
-import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE } from "@/lib/tokens";
+import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE_OVERLAY } from "@/lib/tokens";
 import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload } from "@/lib/searchResults";
 import { QUICK_CHIPS, AMENITY_CHIPS } from "@/lib/chips";
 import { CampsitePin } from "./CampsitePin";
@@ -988,7 +988,7 @@ export default function MapView() {
       {isInitialLoading && (
         <div
           className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 backdrop-blur-sm"
-          style={{ background: `${SURFACE}d2` }}
+          style={{ background: SURFACE_OVERLAY }}
         >
           <div
             className="w-12 h-12 rounded-full animate-spin"

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -13,7 +13,7 @@ import BottomDrawer, {
   getDrawerHeightPx,
 } from "./BottomDrawer";
 import type { AmenityPOI, Campsite } from "@/types/map";
-import { CORAL, FOREST_GREEN } from "@/lib/tokens";
+import { BORDER, CORAL, FOREST_GREEN, SAGE } from "@/lib/tokens";
 import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload } from "@/lib/searchResults";
 import { QUICK_CHIPS, AMENITY_CHIPS } from "@/lib/chips";
 import { CampsitePin } from "./CampsitePin";
@@ -215,11 +215,13 @@ export default function MapView() {
     campsites,
     hasMore,
     amenityPois,
+    isInitialLoading,
     weatherCacheRef,
     loadCampsites,
     loadAmenities,
     loadWeatherForViewport,
     setSearchResults,
+    markInitialLoaded,
   } = useMapData({
     drawerStateRef,
     activeFiltersRef,
@@ -434,6 +436,7 @@ export default function MapView() {
         // pan invalidates this fetch and loadWeatherForViewport runs again for the
         // new visible set.
         loadWeatherForViewport(e.target, searchPayload.campsites);
+        markInitialLoaded();
         return;
       }
 
@@ -461,7 +464,7 @@ export default function MapView() {
         loadAmenities(e.target);
       }
     },
-    [loadCampsites, loadAmenities, loadWeatherForViewport, setSearchResults]
+    [loadCampsites, loadAmenities, loadWeatherForViewport, setSearchResults, markInitialLoaded]
   );
 
   const handleMoveEnd = useCallback(
@@ -979,6 +982,28 @@ export default function MapView() {
           );
         })}
       </MapGL>
+
+      {/* Initial load spinner — shown until first campsite fetch resolves.
+          z-20 sits above map markers (max z-index 10) but below the drawer (z-50). */}
+      {isInitialLoading && (
+        <div
+          className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3"
+          style={{ background: "rgba(247,245,240,0.82)", backdropFilter: "blur(4px)" }}
+        >
+          <div
+            className="w-12 h-12 rounded-full animate-spin"
+            style={{ border: `3px solid ${BORDER}`, borderTopColor: CORAL }}
+          />
+          <div className="text-center">
+            <p className="font-serif text-base font-bold mb-1" style={{ color: FOREST_GREEN }}>
+              Finding the best spots…
+            </p>
+            <p className="text-xs" style={{ color: SAGE }}>
+              Loading campsites nearby
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Bottom drawer — z-50 must exceed marker z-index (max 10) */}
       {showDrawer && (

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -13,7 +13,7 @@ import BottomDrawer, {
   getDrawerHeightPx,
 } from "./BottomDrawer";
 import type { AmenityPOI, Campsite } from "@/types/map";
-import { BORDER, CORAL, FOREST_GREEN, SAGE } from "@/lib/tokens";
+import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE } from "@/lib/tokens";
 import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload } from "@/lib/searchResults";
 import { QUICK_CHIPS, AMENITY_CHIPS } from "@/lib/chips";
 import { CampsitePin } from "./CampsitePin";
@@ -987,15 +987,15 @@ export default function MapView() {
           z-20 sits above map markers (max z-index 10) but below the drawer (z-50). */}
       {isInitialLoading && (
         <div
-          className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3"
-          style={{ background: "rgba(247,245,240,0.82)", backdropFilter: "blur(4px)" }}
+          className="absolute inset-0 z-20 flex flex-col items-center justify-center gap-3 backdrop-blur-sm"
+          style={{ background: `${SURFACE}d2` }}
         >
           <div
             className="w-12 h-12 rounded-full animate-spin"
             style={{ border: `3px solid ${BORDER}`, borderTopColor: CORAL }}
           />
           <div className="text-center">
-            <p className="font-serif text-base font-bold mb-1" style={{ color: FOREST_GREEN }}>
+            <p className="font-[family-name:var(--font-lora)] text-base font-bold mb-1" style={{ color: FOREST_GREEN }}>
               Pitching the best spots…
             </p>
             <p className="text-xs" style={{ color: SAGE }}>

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -392,6 +392,9 @@ export function useMapData({
           loadWeatherForViewport(map, results);
         }
       })
+      // fetchCampsites has an internal try/catch and always resolves — this .catch()
+      // is a defensive guard in case that invariant ever changes (e.g. a future refactor
+      // that lets network errors propagate).
       .catch(() => {
         if (id !== fetchCounterRef.current) return;
         setIsFetching(false);
@@ -405,6 +408,12 @@ export function useMapData({
   }, [loadWeatherForViewport, setDrawerState, setSelectedIdx]);
 
   const setSearchResults = useCallback((newCampsites: Campsite[]) => {
+    // Clear the initial overlay immediately so AI search arrivals and inline map
+    // searches don't flash the spinner — covers both handleLoad and handleMapSearch paths.
+    if (!hasInitiallyLoadedRef.current) {
+      hasInitiallyLoadedRef.current = true;
+      setIsInitialLoading(false);
+    }
     setCampsites(newCampsites);
     campsitesRef.current = newCampsites;
     prevCampsitesLengthRef.current = newCampsites.length;

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -207,6 +207,9 @@ export type UseMapDataReturn = {
   campsites: Campsite[];
   hasMore: boolean;
   amenityPois: AmenityPOI[];
+  // True until the first loadCampsites fetch resolves (browse mode initial load).
+  // Map.tsx uses this to show a centered spinner overlay.
+  isInitialLoading: boolean;
   // Exposed so Map.tsx can pre-populate cache from AI search response weather,
   // avoiding a redundant /api/weather/batch round-trip after results arrive.
   weatherCacheRef: MutableRefObject<Map<string, WeatherDay[] | null>>;
@@ -217,6 +220,8 @@ export type UseMapDataReturn = {
   // Atomically updates campsites state, campsitesRef, and prevCampsitesLengthRef.
   // Use instead of setCampsites for AI-search result paths so all three stay in sync.
   setSearchResults: (campsites: Campsite[]) => void;
+  // Call when AI search results are loaded directly (skips loadCampsites path).
+  markInitialLoaded: () => void;
 };
 
 export function useMapData({
@@ -233,6 +238,7 @@ export function useMapData({
   const [campsites, setCampsites] = useState<Campsite[]>([]);
   const [hasMore, setHasMore] = useState(false);
   const [amenityPois, setAmenityPois] = useState<AmenityPOI[]>([]);
+  const [isInitialLoading, setIsInitialLoading] = useState(true);
 
   // Monotonic counter — discard results from stale in-flight requests
   const fetchCounterRef = useRef(0);
@@ -249,6 +255,8 @@ export function useMapData({
   const weatherCacheRef = useRef<Map<string, WeatherDay[] | null>>(new Map());
   // Mirrors campsites state for stable callbacks (handleMoveEnd AI pan path).
   const campsitesRef = useRef<Campsite[]>([]);
+  // Guards isInitialLoading so it only clears once (on first loadCampsites resolve).
+  const hasInitiallyLoadedRef = useRef(false);
 
   // Keeps campsitesRef in sync with campsites state so stable callbacks
   // (loadWeatherForViewport default path) always read the latest list.
@@ -333,6 +341,11 @@ export function useMapData({
     []
   );
 
+  const markInitialLoaded = useCallback(() => {
+    hasInitiallyLoadedRef.current = true;
+    setIsInitialLoading(false);
+  }, []);
+
   const loadCampsites = useCallback((map: mapboxgl.Map) => {
     const id = ++fetchCounterRef.current;
     const bounds = computeVisibleBounds(map, getDrawerHeightPx(drawerStateRef.current));
@@ -340,6 +353,10 @@ export function useMapData({
     const amenities = [...filters.activities, ...filters.pois];
     fetchCampsites(bounds, amenities).then(({ results, hasMore: newHasMore }) => {
       if (id !== fetchCounterRef.current) return; // stale fetch — discard
+      if (!hasInitiallyLoadedRef.current) {
+        hasInitiallyLoadedRef.current = true;
+        setIsInitialLoading(false);
+      }
       cardRefs.current = [];
       // Re-open to half only on 0 → results transition.
       // Also sync map padding so Mapbox knows the drawer now covers ~52vh —
@@ -403,10 +420,12 @@ export function useMapData({
     campsites,
     hasMore,
     amenityPois,
+    isInitialLoading,
     weatherCacheRef,
     loadCampsites,
     loadAmenities,
     loadWeatherForViewport,
     setSearchResults,
+    markInitialLoaded,
   };
 }

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -210,6 +210,8 @@ export type UseMapDataReturn = {
   // True until the first loadCampsites fetch resolves (browse mode initial load).
   // Map.tsx uses this to show a centered spinner overlay.
   isInitialLoading: boolean;
+  // True while any loadCampsites fetch is in flight (pan/zoom refetches).
+  isFetching: boolean;
   // Exposed so Map.tsx can pre-populate cache from AI search response weather,
   // avoiding a redundant /api/weather/batch round-trip after results arrive.
   weatherCacheRef: MutableRefObject<Map<string, WeatherDay[] | null>>;
@@ -239,6 +241,7 @@ export function useMapData({
   const [hasMore, setHasMore] = useState(false);
   const [amenityPois, setAmenityPois] = useState<AmenityPOI[]>([]);
   const [isInitialLoading, setIsInitialLoading] = useState(true);
+  const [isFetching, setIsFetching] = useState(false);
 
   // Monotonic counter — discard results from stale in-flight requests
   const fetchCounterRef = useRef(0);
@@ -348,11 +351,13 @@ export function useMapData({
 
   const loadCampsites = useCallback((map: mapboxgl.Map) => {
     const id = ++fetchCounterRef.current;
+    setIsFetching(true);
     const bounds = computeVisibleBounds(map, getDrawerHeightPx(drawerStateRef.current));
     const filters = activeFiltersRef.current;
     const amenities = [...filters.activities, ...filters.pois];
     fetchCampsites(bounds, amenities).then(({ results, hasMore: newHasMore }) => {
       if (id !== fetchCounterRef.current) return; // stale fetch — discard
+      setIsFetching(false);
       if (!hasInitiallyLoadedRef.current) {
         hasInitiallyLoadedRef.current = true;
         setIsInitialLoading(false);
@@ -421,6 +426,7 @@ export function useMapData({
     hasMore,
     amenityPois,
     isInitialLoading,
+    isFetching,
     weatherCacheRef,
     loadCampsites,
     loadAmenities,

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -359,10 +359,7 @@ export function useMapData({
       .then(({ results, hasMore: newHasMore }) => {
         if (id !== fetchCounterRef.current) return; // stale fetch — discard
         setIsFetching(false);
-        if (!hasInitiallyLoadedRef.current) {
-          hasInitiallyLoadedRef.current = true;
-          setIsInitialLoading(false);
-        }
+        markInitialLoaded();
         cardRefs.current = [];
         // Re-open to half only on 0 → results transition.
         // Also sync map padding so Mapbox knows the drawer now covers ~52vh —
@@ -398,22 +395,16 @@ export function useMapData({
       .catch(() => {
         if (id !== fetchCounterRef.current) return;
         setIsFetching(false);
-        if (!hasInitiallyLoadedRef.current) {
-          hasInitiallyLoadedRef.current = true;
-          setIsInitialLoading(false);
-        }
+        markInitialLoaded();
       });
   // drawerStateRef, activeFiltersRef, selectedIdRef, cardRefs, skipNextFetch are stable refs.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadWeatherForViewport, setDrawerState, setSelectedIdx]);
+  }, [loadWeatherForViewport, markInitialLoaded, setDrawerState, setSelectedIdx]);
 
   const setSearchResults = useCallback((newCampsites: Campsite[]) => {
     // Clear the initial overlay immediately so AI search arrivals and inline map
     // searches don't flash the spinner — covers both handleLoad and handleMapSearch paths.
-    if (!hasInitiallyLoadedRef.current) {
-      hasInitiallyLoadedRef.current = true;
-      setIsInitialLoading(false);
-    }
+    markInitialLoaded();
     setCampsites(newCampsites);
     campsitesRef.current = newCampsites;
     prevCampsitesLengthRef.current = newCampsites.length;

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -345,6 +345,7 @@ export function useMapData({
   );
 
   const markInitialLoaded = useCallback(() => {
+    if (hasInitiallyLoadedRef.current) return;
     hasInitiallyLoadedRef.current = true;
     setIsInitialLoading(false);
   }, []);
@@ -408,7 +409,7 @@ export function useMapData({
     setCampsites(newCampsites);
     campsitesRef.current = newCampsites;
     prevCampsitesLengthRef.current = newCampsites.length;
-  }, []);
+  }, [markInitialLoaded]);
 
   const loadAmenities = useCallback((map: mapboxgl.Map) => {
     const poiTypes = activeFiltersRef.current.pois;

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -355,42 +355,51 @@ export function useMapData({
     const bounds = computeVisibleBounds(map, getDrawerHeightPx(drawerStateRef.current));
     const filters = activeFiltersRef.current;
     const amenities = [...filters.activities, ...filters.pois];
-    fetchCampsites(bounds, amenities).then(({ results, hasMore: newHasMore }) => {
-      if (id !== fetchCounterRef.current) return; // stale fetch — discard
-      setIsFetching(false);
-      if (!hasInitiallyLoadedRef.current) {
-        hasInitiallyLoadedRef.current = true;
-        setIsInitialLoading(false);
-      }
-      cardRefs.current = [];
-      // Re-open to half only on 0 → results transition.
-      // Also sync map padding so Mapbox knows the drawer now covers ~52vh —
-      // without this, pin centering and bounds computation stay at PEEK_HEIGHT_PX
-      // until the next user-triggered easeTo. skipNextFetch suppresses the
-      // moveend that setPadding's internal easeTo(duration:0) fires.
-      if (results.length > 0 && prevCampsitesLengthRef.current === 0) {
-        setDrawerState("half");
-        skipNextFetch.current = true;
-        map.setPadding({ top: 0, right: 0, bottom: getDrawerHeightPx("half"), left: 0 });
-      }
-      prevCampsitesLengthRef.current = results.length;
-      setHasMore(newHasMore);
-      const newIdx = selectedIdRef.current
-        ? results.findIndex((c) => c.id === selectedIdRef.current)
-        : -1;
-      setSelectedIdx(newIdx >= 0 ? newIdx : null);
-      if (newIdx < 0) selectedIdRef.current = null;
-      // loadWeatherForViewport sets campsites state (with cache applied) for non-empty
-      // results. For empty results it returns early, so clear the list explicitly.
-      if (results.length === 0) {
-        setCampsites([]);
-      } else {
-        // Fetch weather only for visible pins not already cached client-side.
-        // loadWeatherForViewport increments weatherFetchCounterRef internally, so
-        // any in-flight fetch from a previous loadCampsites call is invalidated.
-        loadWeatherForViewport(map, results);
-      }
-    });
+    fetchCampsites(bounds, amenities)
+      .then(({ results, hasMore: newHasMore }) => {
+        if (id !== fetchCounterRef.current) return; // stale fetch — discard
+        setIsFetching(false);
+        if (!hasInitiallyLoadedRef.current) {
+          hasInitiallyLoadedRef.current = true;
+          setIsInitialLoading(false);
+        }
+        cardRefs.current = [];
+        // Re-open to half only on 0 → results transition.
+        // Also sync map padding so Mapbox knows the drawer now covers ~52vh —
+        // without this, pin centering and bounds computation stay at PEEK_HEIGHT_PX
+        // until the next user-triggered easeTo. skipNextFetch suppresses the
+        // moveend that setPadding's internal easeTo(duration:0) fires.
+        if (results.length > 0 && prevCampsitesLengthRef.current === 0) {
+          setDrawerState("half");
+          skipNextFetch.current = true;
+          map.setPadding({ top: 0, right: 0, bottom: getDrawerHeightPx("half"), left: 0 });
+        }
+        prevCampsitesLengthRef.current = results.length;
+        setHasMore(newHasMore);
+        const newIdx = selectedIdRef.current
+          ? results.findIndex((c) => c.id === selectedIdRef.current)
+          : -1;
+        setSelectedIdx(newIdx >= 0 ? newIdx : null);
+        if (newIdx < 0) selectedIdRef.current = null;
+        // loadWeatherForViewport sets campsites state (with cache applied) for non-empty
+        // results. For empty results it returns early, so clear the list explicitly.
+        if (results.length === 0) {
+          setCampsites([]);
+        } else {
+          // Fetch weather only for visible pins not already cached client-side.
+          // loadWeatherForViewport increments weatherFetchCounterRef internally, so
+          // any in-flight fetch from a previous loadCampsites call is invalidated.
+          loadWeatherForViewport(map, results);
+        }
+      })
+      .catch(() => {
+        if (id !== fetchCounterRef.current) return;
+        setIsFetching(false);
+        if (!hasInitiallyLoadedRef.current) {
+          hasInitiallyLoadedRef.current = true;
+          setIsInitialLoading(false);
+        }
+      });
   // drawerStateRef, activeFiltersRef, selectedIdRef, cardRefs, skipNextFetch are stable refs.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loadWeatherForViewport, setDrawerState, setSelectedIdx]);

--- a/app/lib/tokens.ts
+++ b/app/lib/tokens.ts
@@ -7,5 +7,6 @@ export const FOREST_GREEN = "#2d4a2d";
 export const TEXT = "#1a2e1a"; // near-black with green tint — darkest text, matches C.text in prototype
 export const SAGE = "#5a7a5a";
 export const SURFACE = "#f7f5f0";
+export const SURFACE_OVERLAY = `${SURFACE}d2`; // SURFACE at ~82% opacity — used for loading overlays
 export const BORDER = "#e0dbd0";
 export const TEXT_MUTED = "#8a9e8a";


### PR DESCRIPTION
## Summary

- Centered spinner overlay on initial map load (semi-transparent warm bg + blur, coral spinner, "Pitching the best spots…" heading) — clears once the first campsite fetch resolves
- Ghost drawer visible at peek state from the start, showing "0 campsites found" while loading (was blank)
- Pulsing result label + coral spinner in the drawer handle while pan/zoom refetches are in flight

## Test plan

- [ ] Browse mode (`/map` direct): spinner overlay appears, clears when cards load, drawer shows "0 campsites found" then updates
- [ ] AI search mode (search from home → map): no spinner overlay, results show immediately
- [ ] Pan or zoom the map: result label pulses and spinner appears next to count, both clear when results arrive
- [ ] No layout shift at any point during load

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)