### PR TITLE
fix(weather): resolve batch cache write timeouts and 400 on large viewports

### DIFF
--- a/app/app/api/weather/batch/route.ts
+++ b/app/app/api/weather/batch/route.ts
@@ -5,11 +5,12 @@
 import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/apiAuth";
 import { Prisma } from "@/lib/generated/prisma/client";
+import { WEATHER_MAX_LOCATIONS } from "@/lib/weatherConstants";
 
 const OPEN_METEO_URL = "https://api.open-meteo.com/v1/forecast";
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 const FETCH_TIMEOUT_MS = 10_000; // 10 seconds per location
-const MAX_LOCATIONS = 100;
+const MAX_LOCATIONS = WEATHER_MAX_LOCATIONS;
 // Maximum concurrent Open-Meteo requests to avoid overwhelming the free tier
 const CONCURRENCY = 10;
 
@@ -193,6 +194,7 @@ export async function POST(req: Request): Promise<Response> {
                 expiresAt,
                 forecastJson,
               })),
+              skipDuplicates: true,
             }),
           ]);
         } catch (cacheErr) {

--- a/app/app/api/weather/batch/route.ts
+++ b/app/app/api/weather/batch/route.ts
@@ -164,27 +164,41 @@ export async function POST(req: Request): Promise<Response> {
         CONCURRENCY
       );
 
-      // Write successful fetches to cache and attach to results
-      const fetchedAt = new Date();
-      const expiresAt = new Date(fetchedAt.getTime() + CACHE_TTL_MS);
+      // Attach all results (null for failed fetches)
+      for (let i = 0; i < misses.length; i++) {
+        results[misses[i].id] = fetched[i];
+      }
 
-      await Promise.all(
-        misses.map(async (loc, i) => {
-          const forecastJson = fetched[i];
-          results[loc.id] = forecastJson;
-          if (forecastJson !== null) {
-            try {
-              await prisma.weatherCache.upsert({
-                where: { lat_lng: { lat: loc.lat, lng: loc.lng } },
-                update: { fetchedAt, expiresAt, forecastJson },
-                create: { lat: loc.lat, lng: loc.lng, fetchedAt, expiresAt, forecastJson },
-              });
-            } catch (cacheErr) {
-              console.error("[POST /api/weather/batch] Cache write failed", loc.lat, loc.lng, cacheErr);
-            }
-          }
-        })
-      );
+      // Batch all successful fetches into a single transaction — avoids N concurrent
+      // upserts that exhaust the DB connection pool under large miss counts.
+      const cacheWrites = misses
+        .map((loc, i) => ({ loc, forecastJson: fetched[i] }))
+        .filter((item): item is { loc: Location; forecastJson: Prisma.InputJsonValue } =>
+          item.forecastJson !== null
+        );
+
+      if (cacheWrites.length > 0) {
+        const fetchedAt = new Date();
+        const expiresAt = new Date(fetchedAt.getTime() + CACHE_TTL_MS);
+        try {
+          await prisma.$transaction([
+            prisma.weatherCache.deleteMany({
+              where: { OR: cacheWrites.map(({ loc }) => ({ lat: loc.lat, lng: loc.lng })) },
+            }),
+            prisma.weatherCache.createMany({
+              data: cacheWrites.map(({ loc, forecastJson }) => ({
+                lat: loc.lat,
+                lng: loc.lng,
+                fetchedAt,
+                expiresAt,
+                forecastJson,
+              })),
+            }),
+          ]);
+        } catch (cacheErr) {
+          console.error("[POST /api/weather/batch] Cache write failed", cacheErr);
+        }
+      }
     }
 
     return Response.json({ results });

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -4,7 +4,7 @@ import type { DrawerState } from "@/components/BottomDrawer";
 import { getDrawerHeightPx } from "@/components/BottomDrawer";
 import type { FilterState } from "@/components/FilterPanel";
 import type { AmenityPOI, Campsite, WeatherDay } from "@/types/map";
-import { fetchWeatherBatch, extractWeatherForecast } from "@/lib/fetchWeatherBatch";
+import { fetchWeatherBatch } from "@/lib/fetchWeatherBatch";
 import type mapboxgl from "mapbox-gl";
 
 export type Bounds = { north: number; south: number; east: number; west: number };

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -3,8 +3,8 @@ import type { Dispatch, MutableRefObject, SetStateAction } from "react";
 import type { DrawerState } from "@/components/BottomDrawer";
 import { getDrawerHeightPx } from "@/components/BottomDrawer";
 import type { FilterState } from "@/components/FilterPanel";
-import { DAY_NAMES } from "@/types/map";
 import type { AmenityPOI, Campsite, WeatherDay } from "@/types/map";
+import { fetchWeatherBatch, extractWeatherForecast } from "@/lib/fetchWeatherBatch";
 import type mapboxgl from "mapbox-gl";
 
 export type Bounds = { north: number; south: number; east: number; west: number };
@@ -30,109 +30,6 @@ async function fetchCampsites(bounds: Bounds, amenities: string[] = []): Promise
   } catch (e) {
     console.warn("[fetchCampsites] fetch failed", e);
     return { results: [], hasMore: false };
-  }
-}
-
-// Extracts weather data from an Open-Meteo forecast response.
-// When startDate/endDate are provided, only days within that range are included
-// (matching the date window used for ranking). Without dates, falls back to the
-// first MAX_FORECAST_DAYS (4) days — intentionally wider than the server-side
-// extractForecastDays default (today+tomorrow) because browse-mode cards show
-// more days than the 2-day ranking window needs.
-// See also: extractForecastDays in app/lib/weatherRanking.ts (server-side counterpart).
-// Returns null if the response shape is unexpected; gracefully handles absent
-// precipitation_probability_max (old cache entries) by setting null.
-const MAX_FORECAST_DAYS = 4;
-function extractWeatherForecast(
-  forecast: unknown,
-  startDate?: string | null,
-  endDate?: string | null,
-): WeatherDay[] | null {
-  if (typeof forecast !== "object" || forecast === null) return null;
-  const f = forecast as Record<string, unknown>;
-  if (typeof f.daily !== "object" || f.daily === null) return null;
-  const d = f.daily as Record<string, unknown>;
-  if (!Array.isArray(d.temperature_2m_max) || !Array.isArray(d.temperature_2m_min)) return null;
-  if (!Array.isArray(d.precipitation_sum) || !Array.isArray(d.weathercode)) return null;
-  if (!Array.isArray(d.time)) return null;
-
-  const probArr = Array.isArray(d.precipitation_probability_max)
-    ? (d.precipitation_probability_max as unknown[])
-    : null;
-
-  const days: WeatherDay[] = [];
-  for (let i = 0; i < (d.time as unknown[]).length; i++) {
-    const dateStr = d.time[i];
-    if (typeof dateStr !== "string") continue;
-
-    // Date range filter:
-    // - Full range supplied: show only days within [startDate, endDate].
-    // - startDate only (partial range): show MAX_FORECAST_DAYS days from startDate.
-    // - No dates (browse mode): show first MAX_FORECAST_DAYS days of the forecast.
-    if (startDate && endDate) {
-      if (dateStr < startDate || dateStr > endDate) continue;
-    } else if (startDate) {
-      if (dateStr < startDate) continue;
-      if (days.length >= MAX_FORECAST_DAYS) break;
-    } else if (days.length >= MAX_FORECAST_DAYS) {
-      break;
-    }
-
-    const tempMax = d.temperature_2m_max[i];
-    const tempMin = d.temperature_2m_min[i];
-    const precipitationSum = d.precipitation_sum[i];
-    const weatherCode = d.weathercode[i];
-    // Skip malformed days rather than aborting the whole array. Day 0 is the
-    // most critical (shown in compact mode); if it is missing, the caller
-    // receives a shorter array and the WeatherStrip shows fewer segments.
-    if (typeof tempMax !== "number" || typeof tempMin !== "number") continue;
-    if (typeof precipitationSum !== "number" || typeof weatherCode !== "number") continue;
-    // T00:00:00 forces local-time midnight parsing — without it, `new Date("2024-03-23")`
-    // is parsed as UTC midnight and .getDay() returns the wrong day in UTC+ timezones.
-    const dow = new Date(dateStr + "T00:00:00").getDay();
-    const precipProbRaw = probArr?.[i];
-    days.push({
-      date: dateStr,
-      dayName: DAY_NAMES[dow],
-      tempMax,
-      tempMin,
-      precipitationSum,
-      precipProbability: typeof precipProbRaw === "number" ? precipProbRaw : null,
-      weatherCode,
-    });
-  }
-  return days.length > 0 ? days : null;
-}
-
-// Fetches weather for a batch of campsites from /api/weather/batch.
-// startDate/endDate filter the displayed days to the search date window (when supplied).
-// Returns the same array with weather attached — failures result in weather: null.
-// Never throws; errors are logged and each campsite gets weather: null.
-async function fetchWeatherBatch(
-  campsites: Campsite[],
-  startDate?: string | null,
-  endDate?: string | null,
-): Promise<Campsite[]> {
-  if (campsites.length === 0) return campsites;
-  const locations = campsites.map((c) => ({ id: c.id, lat: c.lat, lng: c.lng }));
-  try {
-    const res = await fetch("/api/weather/batch", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ locations }),
-    });
-    if (!res.ok) {
-      console.warn(`[fetchWeatherBatch] ${res.status} ${res.statusText}`);
-      return campsites.map((c) => ({ ...c, weather: null }));
-    }
-    const data = (await res.json()) as { results: Record<string, unknown> };
-    return campsites.map((c) => ({
-      ...c,
-      weather: extractWeatherForecast(data.results[c.id], startDate, endDate) ?? null,
-    }));
-  } catch (e) {
-    console.warn("[fetchWeatherBatch] fetch failed", e);
-    return campsites.map((c) => ({ ...c, weather: null }));
   }
 }
 

--- a/app/lib/fetchWeatherBatch.ts
+++ b/app/lib/fetchWeatherBatch.ts
@@ -1,0 +1,108 @@
+import type { Campsite, WeatherDay } from "@/types/map";
+import { DAY_NAMES } from "@/types/map";
+
+// Must not exceed MAX_LOCATIONS in /api/weather/batch/route.ts
+const WEATHER_BATCH_SIZE = 100;
+
+const MAX_FORECAST_DAYS = 4;
+
+export function extractWeatherForecast(
+  forecast: unknown,
+  startDate?: string | null,
+  endDate?: string | null,
+): WeatherDay[] | null {
+  if (typeof forecast !== "object" || forecast === null) return null;
+  const f = forecast as Record<string, unknown>;
+  if (typeof f.daily !== "object" || f.daily === null) return null;
+  const d = f.daily as Record<string, unknown>;
+  if (!Array.isArray(d.temperature_2m_max) || !Array.isArray(d.temperature_2m_min)) return null;
+  if (!Array.isArray(d.precipitation_sum) || !Array.isArray(d.weathercode)) return null;
+  if (!Array.isArray(d.time)) return null;
+
+  const probArr = Array.isArray(d.precipitation_probability_max)
+    ? (d.precipitation_probability_max as unknown[])
+    : null;
+
+  const days: WeatherDay[] = [];
+  for (let i = 0; i < (d.time as unknown[]).length; i++) {
+    const dateStr = d.time[i];
+    if (typeof dateStr !== "string") continue;
+
+    if (startDate && endDate) {
+      if (dateStr < startDate || dateStr > endDate) continue;
+    } else if (startDate) {
+      if (dateStr < startDate) continue;
+      if (days.length >= MAX_FORECAST_DAYS) break;
+    } else if (days.length >= MAX_FORECAST_DAYS) {
+      break;
+    }
+
+    const tempMax = d.temperature_2m_max[i];
+    const tempMin = d.temperature_2m_min[i];
+    const precipitationSum = d.precipitation_sum[i];
+    const weatherCode = d.weathercode[i];
+    if (typeof tempMax !== "number" || typeof tempMin !== "number") continue;
+    if (typeof precipitationSum !== "number" || typeof weatherCode !== "number") continue;
+    const dow = new Date(dateStr + "T00:00:00").getDay();
+    const precipProbRaw = probArr?.[i];
+    days.push({
+      date: dateStr,
+      dayName: DAY_NAMES[dow],
+      tempMax,
+      tempMin,
+      precipitationSum,
+      precipProbability: typeof precipProbRaw === "number" ? precipProbRaw : null,
+      weatherCode,
+    });
+  }
+  return days.length > 0 ? days : null;
+}
+
+async function fetchChunk(
+  campsites: Campsite[],
+  startDate?: string | null,
+  endDate?: string | null,
+): Promise<Campsite[]> {
+  const locations = campsites.map((c) => ({ id: c.id, lat: c.lat, lng: c.lng }));
+  try {
+    const res = await fetch("/api/weather/batch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ locations }),
+    });
+    if (!res.ok) {
+      console.warn(`[fetchWeatherBatch] ${res.status} ${res.statusText}`);
+      return campsites.map((c) => ({ ...c, weather: null }));
+    }
+    const data = (await res.json()) as { results: Record<string, unknown> };
+    return campsites.map((c) => ({
+      ...c,
+      weather: extractWeatherForecast(data.results[c.id], startDate, endDate) ?? null,
+    }));
+  } catch (e) {
+    console.warn("[fetchWeatherBatch] fetch failed", e);
+    return campsites.map((c) => ({ ...c, weather: null }));
+  }
+}
+
+// Fetches weather for a batch of campsites from /api/weather/batch.
+// Splits into chunks of WEATHER_BATCH_SIZE to stay within the server limit.
+// startDate/endDate filter the displayed days to the search date window (when supplied).
+// Never throws; errors are logged and each campsite gets weather: null.
+export async function fetchWeatherBatch(
+  campsites: Campsite[],
+  startDate?: string | null,
+  endDate?: string | null,
+): Promise<Campsite[]> {
+  if (campsites.length === 0) return campsites;
+
+  const chunks: Campsite[][] = [];
+  for (let i = 0; i < campsites.length; i += WEATHER_BATCH_SIZE) {
+    chunks.push(campsites.slice(i, i + WEATHER_BATCH_SIZE));
+  }
+
+  const chunkResults = await Promise.all(
+    chunks.map((chunk) => fetchChunk(chunk, startDate, endDate))
+  );
+  return chunkResults.flat();
+}

--- a/app/lib/fetchWeatherBatch.ts
+++ b/app/lib/fetchWeatherBatch.ts
@@ -1,12 +1,12 @@
 import type { Campsite, WeatherDay } from "@/types/map";
 import { DAY_NAMES } from "@/types/map";
+import { WEATHER_MAX_LOCATIONS } from "@/lib/weatherConstants";
 
-// Must not exceed MAX_LOCATIONS in /api/weather/batch/route.ts
-const WEATHER_BATCH_SIZE = 100;
+const WEATHER_BATCH_SIZE = WEATHER_MAX_LOCATIONS;
 
 const MAX_FORECAST_DAYS = 4;
 
-export function extractWeatherForecast(
+function extractWeatherForecast(
   forecast: unknown,
   startDate?: string | null,
   endDate?: string | null,

--- a/app/lib/weatherConstants.ts
+++ b/app/lib/weatherConstants.ts
@@ -1,0 +1,3 @@
+// Maximum locations per /api/weather/batch request.
+// Imported by both the route (enforces the limit) and fetchWeatherBatch (chunks to this size).
+export const WEATHER_MAX_LOCATIONS = 100;

--- a/app/lib/weatherRanking.ts
+++ b/app/lib/weatherRanking.ts
@@ -40,7 +40,7 @@ const NEUTRAL_WEATHER_SCORE = 50;
  * 2-day window used for ranking when no trip dates are known. This intentionally
  * differs from the client-side extractWeatherForecast (Map.tsx) which defaults
  * to MAX_FORECAST_DAYS (4) for browse-mode card display.
- * See also: extractWeatherForecast in app/components/Map.tsx (client-side counterpart).
+ * See also: extractWeatherForecast in app/lib/fetchWeatherBatch.ts (client-side counterpart).
  * Returns an empty array if the shape is unexpected.
  */
 export function extractForecastDays(

--- a/app/tests/api/weatherBatch.test.ts
+++ b/app/tests/api/weatherBatch.test.ts
@@ -218,6 +218,13 @@ describe("POST /api/weather/batch", () => {
     const body = await res.json();
     expect(body.results[LOC_A.id]).toEqual(MOCK_FORECAST);
     expect(vi.mocked(fetch)).toHaveBeenCalledOnce();
+
+    // Verify the stale record was replaced — with deleteMany+createMany a bug in the
+    // delete clause could leave the old row untouched and the test wouldn't catch it.
+    const record = await prisma.weatherCache.findUnique({
+      where: { lat_lng: { lat: LOC_A.lat, lng: LOC_A.lng } },
+    });
+    expect(record?.forecastJson).toEqual(MOCK_FORECAST);
   });
 
   // --- Deduplication ---

--- a/app/tests/api/weatherBatch.test.ts
+++ b/app/tests/api/weatherBatch.test.ts
@@ -31,6 +31,7 @@ const MOCK_FORECAST = {
 // to avoid cache record collisions when test files run in parallel.
 const LOC_A = { id: "camp-a", lat: -37.8136, lng: 144.9631 }; // Melbourne
 const LOC_B = { id: "camp-b", lat: -27.4698, lng: 153.0251 }; // Brisbane
+const LOC_C = { id: "camp-c", lat: -34.9285, lng: 138.6007 }; // Adelaide
 
 function makeRequest(body: unknown) {
   return new Request("http://localhost/api/weather/batch", {
@@ -60,8 +61,9 @@ describe("POST /api/weather/batch", () => {
   });
 
   afterEach(async () => {
-    await cleanupCache(LOC_A, LOC_B);
+    await cleanupCache(LOC_A, LOC_B, LOC_C);
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
     vi.clearAllMocks();
   });
 
@@ -246,5 +248,27 @@ describe("POST /api/weather/batch", () => {
     const body = await res.json();
     expect(body.results[LOC_A.id]).toBeNull();
     expect(body.results[LOC_B.id]).toEqual(MOCK_FORECAST);
+  });
+
+  // --- Batch cache writes ---
+
+  it("writes all cache misses in a single batch instead of individual upserts", async () => {
+    // N concurrent upserts exhaust the DB connection pool — the fix must not call upsert at all.
+    const upsertSpy = vi.spyOn(prisma.weatherCache, "upsert");
+
+    const res = await POST(makeRequest({ locations: [LOC_A, LOC_B, LOC_C] }));
+    expect(res.status).toBe(200);
+
+    expect(upsertSpy).not.toHaveBeenCalled();
+
+    // All three locations must still be persisted to the cache
+    const [recA, recB, recC] = await Promise.all([
+      prisma.weatherCache.findUnique({ where: { lat_lng: { lat: LOC_A.lat, lng: LOC_A.lng } } }),
+      prisma.weatherCache.findUnique({ where: { lat_lng: { lat: LOC_B.lat, lng: LOC_B.lng } } }),
+      prisma.weatherCache.findUnique({ where: { lat_lng: { lat: LOC_C.lat, lng: LOC_C.lng } } }),
+    ]);
+    expect(recA?.forecastJson).toEqual(MOCK_FORECAST);
+    expect(recB?.forecastJson).toEqual(MOCK_FORECAST);
+    expect(recC?.forecastJson).toEqual(MOCK_FORECAST);
   });
 });

--- a/app/tests/lib/fetchWeatherBatch.test.ts
+++ b/app/tests/lib/fetchWeatherBatch.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchWeatherBatch } from "@/lib/fetchWeatherBatch";
+import type { Campsite } from "@/types/map";
+
+const MOCK_FORECAST = {
+  daily: {
+    time: ["2026-03-23", "2026-03-24"],
+    temperature_2m_max: [22.5, 24.0],
+    temperature_2m_min: [15.1, 16.0],
+    precipitation_sum: [0.0, 1.2],
+    precipitation_probability_max: [10, 40],
+    weathercode: [1, 61],
+  },
+};
+
+function makeCampsites(count: number): Campsite[] {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `c${i}`,
+    name: `Camp ${i}`,
+    lat: -30 + i * 0.001,
+    lng: 150,
+    region: "NSW",
+    blurb: null,
+    amenities: [],
+  }));
+}
+
+function makeResultsMap(campsites: Campsite[]): Record<string, unknown> {
+  return Object.fromEntries(campsites.map((c) => [c.id, MOCK_FORECAST]));
+}
+
+describe("fetchWeatherBatch", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+        const body = JSON.parse(init?.body as string) as { locations: { id: string }[] };
+        const results = makeResultsMap(body.locations.map((l) => ({ id: l.id }) as Campsite));
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ results }),
+        } as Response);
+      })
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("returns an empty array when given no campsites", async () => {
+    const result = await fetchWeatherBatch([]);
+    expect(result).toEqual([]);
+    expect(vi.mocked(fetch)).not.toHaveBeenCalled();
+  });
+
+  it("makes a single request when locations are 100 or fewer", async () => {
+    const campsites = makeCampsites(100);
+    await fetchWeatherBatch(campsites);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    expect(body.locations).toHaveLength(100);
+  });
+
+  it("splits into 2 requests when 150 locations are provided", async () => {
+    const campsites = makeCampsites(150);
+    await fetchWeatherBatch(campsites);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse(vi.mocked(fetch).mock.calls[0][1]?.body as string);
+    const secondBody = JSON.parse(vi.mocked(fetch).mock.calls[1][1]?.body as string);
+    expect(firstBody.locations).toHaveLength(100);
+    expect(secondBody.locations).toHaveLength(50);
+  });
+
+  it("merges weather results from all chunks into the original campsite array order", async () => {
+    const campsites = makeCampsites(150);
+    const result = await fetchWeatherBatch(campsites);
+    expect(result).toHaveLength(150);
+    expect(result[0].id).toBe("c0");
+    expect(result[149].id).toBe("c149");
+    // All should have weather attached from MOCK_FORECAST
+    for (const c of result) {
+      expect(c.weather).not.toBeNull();
+      expect(c.weather!.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("splits into 3 requests for 250 locations", async () => {
+    const campsites = makeCampsites(250);
+    await fetchWeatherBatch(campsites);
+    expect(vi.mocked(fetch)).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns weather: null for all campsites in a chunk when the request fails", async () => {
+    const campsites = makeCampsites(10);
+    vi.mocked(fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    } as Response);
+
+    const result = await fetchWeatherBatch(campsites);
+    expect(result).toHaveLength(10);
+    for (const c of result) {
+      expect(c.weather).toBeNull();
+    }
+  });
+});

--- a/app/tests/lib/fetchWeatherBatch.test.ts
+++ b/app/tests/lib/fetchWeatherBatch.test.ts
@@ -106,4 +106,30 @@ describe("fetchWeatherBatch", () => {
       expect(c.weather).toBeNull();
     }
   });
+
+  it("returns weather for first chunk and null for second when second chunk fails", async () => {
+    // 150 campsites → chunk 1 (c0–c99) succeeds, chunk 2 (c100–c149) fails.
+    // Verifies chunks are independent — a failure in one doesn't affect the other.
+    const campsites = makeCampsites(150);
+    vi.mocked(fetch)
+      .mockImplementationOnce((_url: string, init?: RequestInit) => {
+        const body = JSON.parse(init?.body as string) as { locations: { id: string }[] };
+        const results = makeResultsMap(body.locations.map((l) => ({ id: l.id }) as Campsite));
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ results }) } as Response);
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+      } as Response);
+
+    const result = await fetchWeatherBatch(campsites);
+    expect(result).toHaveLength(150);
+    for (const c of result.slice(0, 100)) {
+      expect(c.weather).not.toBeNull();
+    }
+    for (const c of result.slice(100)) {
+      expect(c.weather).toBeNull();
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- **Server:** Replace N concurrent `prisma.weatherCache.upsert` calls with a single `$transaction([deleteMany, createMany])` — eliminates connection pool exhaustion that caused `Cache write failed … timeout exceeded` errors under load
- **Client:** Extract `fetchWeatherBatch` to `app/lib/fetchWeatherBatch.ts` and chunk requests into batches of 100, fixing the `400 Too many locations` error caused by `PAGE_SIZE=200` exceeding `MAX_LOCATIONS=100`

## Root cause

`PAGE_SIZE` was raised to 200 in #124 but `MAX_LOCATIONS` on the batch endpoint is 100. Any viewport returning a full page triggered the 400. Separately, all cache writes for misses were fired concurrently via `Promise.all`, exhausting the Supabase connection pool.

## Test plan

- [ ] `npm test` passes (220 tests across 10 files)
- [ ] New test: `tests/api/weatherBatch.test.ts` — verifies `upsert` is never called and all cache misses are persisted via batch transaction
- [ ] New test file: `tests/lib/fetchWeatherBatch.test.ts` — 6 unit tests covering chunking (150 → 2 requests, 250 → 3 requests), result merge order, and per-chunk failure handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)