### PR TITLE
fix(map): hide bottom drawer during initial load

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1006,7 +1006,8 @@ export default function MapView() {
       )}
 
       {/* Bottom drawer — hidden during initial load to avoid double loading UI */}
-      {!isInitialLoading && <BottomDrawer
+      {!isInitialLoading && (
+        <BottomDrawer
           campsites={campsites}
           hasMore={hasMore}
           amenityPois={amenityPois}
@@ -1019,7 +1020,8 @@ export default function MapView() {
           onDrawerStateChange={handleDrawerStateChange}
           onSelectPin={selectPin}
           isFetching={isFetching}
-        />}
+        />
+      )}
     </div>
   );
 }

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1005,8 +1005,8 @@ export default function MapView() {
         </div>
       )}
 
-      {/* Bottom drawer — always rendered; shows ghost "0 campsites found" during initial load */}
-      <BottomDrawer
+      {/* Bottom drawer — hidden during initial load to avoid double loading UI */}
+      {!isInitialLoading && <BottomDrawer
           campsites={campsites}
           hasMore={hasMore}
           amenityPois={amenityPois}
@@ -1019,7 +1019,7 @@ export default function MapView() {
           onDrawerStateChange={handleDrawerStateChange}
           onSelectPin={selectPin}
           isFetching={isFetching}
-        />
+        />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Suppresses the `BottomDrawer` while `isInitialLoading` is true so the spinner overlay and the drawer's \"Finding campsites…\" peek strip don't appear simultaneously
- Once the first campsite fetch resolves the overlay unmounts and the drawer mounts normally — no behaviour change after load

## Test plan
- [ ] Open the map screen cold — only the full-screen spinner overlay should appear, no bottom drawer peeking underneath
- [ ] After campsites load the drawer appears in its normal peek state
- [ ] AI search arrivals (via home screen NL query) still show the drawer correctly after load

🤖 Generated with [Claude Code](https://claude.com/claude-code)