### PR TITLE
feat(search): siteName DB filter + amenity-only routing (#129)

### DIFF
--- a/app/app/api/search/route.ts
+++ b/app/app/api/search/route.ts
@@ -150,11 +150,39 @@ export async function POST(req: Request): Promise<Response> {
     const lngDelta =
       radiusKm * DEG_PER_KM / Math.cos((searchLat * Math.PI) / 180);
 
+    // Amenity-only branch — skip the campsite pipeline entirely and return POI results.
+    if (parsedIntent.resultType === "amenities") {
+      const amenityPois = await prisma.amenityPOI.findMany({
+        where: {
+          lat: { gte: searchLat - latDelta, lte: searchLat + latDelta },
+          lng: { gte: searchLng - lngDelta, lte: searchLng + lngDelta },
+          ...(parsedIntent.poiTypes?.length && {
+            amenityType: { key: { in: parsedIntent.poiTypes } },
+          }),
+        },
+        select: {
+          id: true,
+          name: true,
+          lat: true,
+          lng: true,
+          amenityType: { select: { key: true } },
+        },
+        take: RESULT_LIMIT,
+      });
+      return Response.json({ amenityPois, parsedIntent });
+    }
+
     const campsites = await prisma.campsite.findMany({
       where: {
         syncStatus: SyncStatus.active,
         lat: { gte: searchLat - latDelta, lte: searchLat + latDelta },
         lng: { gte: searchLng - lngDelta, lte: searchLng + lngDelta },
+        ...(parsedIntent.siteName && {
+          OR: [
+            { name: { contains: parsedIntent.siteName, mode: "insensitive" } },
+            { region: { contains: parsedIntent.siteName, mode: "insensitive" } },
+          ],
+        }),
         ...(parsedIntent.amenities.length > 0 && {
           amenities: {
             some: {

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -222,6 +222,7 @@ export default function MapView() {
     loadAmenities,
     loadWeatherForViewport,
     setSearchResults,
+    setSearchAmenities,
     markInitialLoaded,
   } = useMapData({
     drawerStateRef,
@@ -441,6 +442,15 @@ export default function MapView() {
         return;
       }
 
+      // Amenity-only search arrival — display POI pins, don't lock the map.
+      // Drawer rendering for this kind is handled in #121; browse mode stays active for campsites.
+      if (searchPayload?.kind === "amenity-search") {
+        initialSearchRef.current = null;
+        searchModeRef.current = false;
+        setSearchAmenities(searchPayload.amenityPois);
+        // Fall through to browse mode so the camera and campsite fetch work normally.
+      }
+
       // Search payload was present but returned no campsites — fall back to browse mode.
       // Reset both refs so handleMoveEnd fires normally and geolocation flyTo works.
       searchModeRef.current = false;
@@ -465,7 +475,7 @@ export default function MapView() {
         loadAmenities(e.target);
       }
     },
-    [loadCampsites, loadAmenities, loadWeatherForViewport, setSearchResults, markInitialLoaded]
+    [loadCampsites, loadAmenities, loadWeatherForViewport, setSearchResults, setSearchAmenities, markInitialLoaded]
   );
 
   const handleMoveEnd = useCallback(

--- a/app/hooks/useMapData.ts
+++ b/app/hooks/useMapData.ts
@@ -119,6 +119,8 @@ export type UseMapDataReturn = {
   // Atomically updates campsites state, campsitesRef, and prevCampsitesLengthRef.
   // Use instead of setCampsites for AI-search result paths so all three stay in sync.
   setSearchResults: (campsites: Campsite[]) => void;
+  // Sets amenityPois directly from an amenity-search payload arrival.
+  setSearchAmenities: (pois: AmenityPOI[]) => void;
   // Call when AI search results are loaded directly (skips loadCampsites path).
   markInitialLoaded: () => void;
 };
@@ -308,6 +310,11 @@ export function useMapData({
     prevCampsitesLengthRef.current = newCampsites.length;
   }, [markInitialLoaded]);
 
+  const setSearchAmenities = useCallback((pois: AmenityPOI[]) => {
+    markInitialLoaded();
+    setAmenityPois(pois);
+  }, [markInitialLoaded]);
+
   const loadAmenities = useCallback((map: mapboxgl.Map) => {
     const poiTypes = activeFiltersRef.current.pois;
     if (poiTypes.length === 0) {
@@ -339,6 +346,7 @@ export function useMapData({
     loadAmenities,
     loadWeatherForViewport,
     setSearchResults,
+    setSearchAmenities,
     markInitialLoaded,
   };
 }

--- a/app/lib/searchResults.ts
+++ b/app/lib/searchResults.ts
@@ -1,7 +1,7 @@
 // Shared types and constants for passing search results from HomeScreen to MapView.
 // Kept in lib/ so neither component imports from the other.
 
-import type { Campsite } from "@/types/map";
+import type { AmenityPOI, Campsite } from "@/types/map";
 import type { ParsedIntent } from "@/lib/parseIntent";
 
 export const SEARCH_RESULTS_KEY = "pitchd:searchResults";
@@ -27,7 +27,16 @@ export type DirectFilterPayload = {
   chipKey: string;
 };
 
-export type SearchResultsPayload = AISearchPayload | DirectFilterPayload;
+// Amenity-only NL search — POI results returned when resultType === "amenities".
+// Campsite pipeline is skipped entirely; drawer rendering for this kind is handled in #121.
+export type AmenitySearchPayload = {
+  kind: "amenity-search";
+  amenityPois: AmenityPOI[];
+  parsedIntent: ParsedIntent;
+  query: string;
+};
+
+export type SearchResultsPayload = AISearchPayload | DirectFilterPayload | AmenitySearchPayload;
 
 // Parses and validates an unknown value (e.g. from JSON.parse) as a SearchResultsPayload.
 // Returns null if the shape is invalid. Exported for unit testing.
@@ -44,6 +53,15 @@ export function parseSearchResultsPayload(parsed: unknown): SearchResultsPayload
     // DB query layer (campsites route filters on known keys via Prisma enum).
     if (!(f.activities as unknown[]).every((a: unknown) => typeof a === "string")) return null;
     if (!(f.pois as unknown[]).every((p: unknown) => typeof p === "string")) return null;
+    return parsed as SearchResultsPayload;
+  }
+
+  if (obj.kind === "amenity-search") {
+    if (!Array.isArray(obj.amenityPois)) return null;
+    const pois = obj.amenityPois as unknown[];
+    if (!pois.every((p) => p !== null && typeof (p as Record<string, unknown>).lat === "number" && typeof (p as Record<string, unknown>).lng === "number")) {
+      return null;
+    }
     return parsed as SearchResultsPayload;
   }
 

--- a/app/tests/api/search.test.ts
+++ b/app/tests/api/search.test.ts
@@ -758,4 +758,212 @@ describe("POST /api/search", () => {
     }));
     expect(res.status).toBe(200);
   });
+
+  // --- siteName filter (Task 2) ---
+
+  it("siteName filter: only returns campsites whose name matches siteName", async () => {
+    const query = "sitename filter name match test";
+    createdHashes.push(hashQuery(query));
+    await prisma.searchCache.deleteMany({ where: { queryHash: hashQuery(query) } });
+
+    const BASE_LAT = -31.95;
+    const BASE_LNG = 141.47;
+    // Two campsites in the same area — only one has the target name
+    const target = await prisma.campsite.create({
+      data: {
+        name: "!Wilsons Promontory Campground",
+        slug: `wilsons-prom-${Date.now()}-${Math.random()}`,
+        lat: -31.96,
+        lng: BASE_LNG,
+        state: "VIC",
+        source: TEST_SOURCE,
+        sourceId: `sitename-target-${Date.now()}-${Math.random()}`,
+      },
+    });
+    const other = await prisma.campsite.create({
+      data: {
+        name: "!Generic Campsite Near Broken Hill",
+        slug: `generic-campsite-${Date.now()}-${Math.random()}`,
+        lat: -31.97,
+        lng: BASE_LNG,
+        state: "NSW",
+        source: TEST_SOURCE,
+        sourceId: `sitename-other-${Date.now()}-${Math.random()}`,
+      },
+    });
+
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: JSON.stringify({
+        location: null,
+        siteName: "Wilsons Promontory",
+        driveTimeHrs: 1,
+        amenities: [],
+        amenityHints: [],
+        startDate: null,
+        endDate: null,
+        sortBy: null,
+        resultType: "campsites",
+        poiTypes: null,
+      }) }],
+    });
+
+    const res = await POST(makeRequest({ query, lat: BASE_LAT, lng: BASE_LNG }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const ids = body.campsites.map((c: { id: string }) => c.id);
+    expect(ids).toContain(target.id);
+    expect(ids).not.toContain(other.id);
+  });
+
+  it("siteName filter: returns empty campsites when no name matches within bounding box", async () => {
+    const query = "sitename filter no match test";
+    createdHashes.push(hashQuery(query));
+    await prisma.searchCache.deleteMany({ where: { queryHash: hashQuery(query) } });
+
+    const BASE_LAT = -31.95;
+    const BASE_LNG = 141.47;
+    // Campsite that does NOT match the siteName
+    await prisma.campsite.create({
+      data: {
+        name: "!Completely Different Name",
+        slug: `sitename-nomatch-${Date.now()}-${Math.random()}`,
+        lat: -31.96,
+        lng: BASE_LNG,
+        state: "NSW",
+        source: TEST_SOURCE,
+        sourceId: `sitename-nomatch-${Date.now()}-${Math.random()}`,
+      },
+    });
+
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: JSON.stringify({
+        location: null,
+        siteName: "XYZ Campground That Does Not Exist",
+        driveTimeHrs: 1,
+        amenities: [],
+        amenityHints: [],
+        startDate: null,
+        endDate: null,
+        sortBy: null,
+        resultType: "campsites",
+        poiTypes: null,
+      }) }],
+    });
+
+    const res = await POST(makeRequest({ query, lat: BASE_LAT, lng: BASE_LNG }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.campsites).toHaveLength(0);
+  });
+
+  // --- Amenity-only routing (Task 3) ---
+
+  it("amenity routing: returns amenityPois (not campsites) when resultType is 'amenities'", async () => {
+    const query = "amenity routing dump points test";
+    createdHashes.push(hashQuery(query));
+    await prisma.searchCache.deleteMany({ where: { queryHash: hashQuery(query) } });
+
+    const BASE_LAT = -31.95;
+    const BASE_LNG = 141.47;
+
+    // Requires the dump_point AmenityType seed row — skip gracefully if not seeded
+    const amenityType = await prisma.amenityType.findUnique({ where: { key: "dump_point" } });
+    if (!amenityType) {
+      console.warn("[search.test] AmenityType 'dump_point' not seeded — skipping amenity routing test. Run `npm run db:seed`.");
+      return;
+    }
+
+    // Seed an AmenityPOI near the test location
+    const poi = await prisma.amenityPOI.create({
+      data: {
+        name: "!Test Dump Point",
+        lat: -31.96,
+        lng: BASE_LNG,
+        amenityTypeId: amenityType.id,
+        source: "test-search",
+        sourceId: `dump-point-${Date.now()}-${Math.random()}`,
+      },
+    });
+
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: JSON.stringify({
+        location: null,
+        siteName: null,
+        driveTimeHrs: 1,
+        amenities: [],
+        amenityHints: [],
+        startDate: null,
+        endDate: null,
+        sortBy: null,
+        resultType: "amenities",
+        poiTypes: ["dump_point"],
+      }) }],
+    });
+
+    const res = await POST(makeRequest({ query, lat: BASE_LAT, lng: BASE_LNG }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    // Amenity-only route: response must have amenityPois, not campsites
+    expect(body).toHaveProperty("amenityPois");
+    expect(body).not.toHaveProperty("campsites");
+    expect(Array.isArray(body.amenityPois)).toBe(true);
+
+    const poiIds = body.amenityPois.map((p: { id: string }) => p.id);
+    expect(poiIds).toContain(poi.id);
+
+    // Clean up the seeded POI
+    await prisma.amenityPOI.deleteMany({ where: { source: "test-search" } });
+  });
+
+  it("amenity routing: when resultType is 'amenities' but poiTypes is empty, returns all nearby POIs", async () => {
+    const query = "amenity routing no poi types test";
+    createdHashes.push(hashQuery(query));
+    await prisma.searchCache.deleteMany({ where: { queryHash: hashQuery(query) } });
+
+    const BASE_LAT = -31.95;
+    const BASE_LNG = 141.47;
+
+    const amenityType = await prisma.amenityType.findUnique({ where: { key: "water_fill" } });
+    if (!amenityType) {
+      console.warn("[search.test] AmenityType 'water_fill' not seeded — skipping test. Run `npm run db:seed`.");
+      return;
+    }
+
+    const poi = await prisma.amenityPOI.create({
+      data: {
+        name: "!Test Water Fill",
+        lat: -31.96,
+        lng: BASE_LNG,
+        amenityTypeId: amenityType.id,
+        source: "test-search",
+        sourceId: `water-fill-${Date.now()}-${Math.random()}`,
+      },
+    });
+
+    mockCreate.mockResolvedValueOnce({
+      content: [{ type: "text", text: JSON.stringify({
+        location: null,
+        siteName: null,
+        driveTimeHrs: 1,
+        amenities: [],
+        amenityHints: [],
+        startDate: null,
+        endDate: null,
+        sortBy: null,
+        resultType: "amenities",
+        poiTypes: [],
+      }) }],
+    });
+
+    const res = await POST(makeRequest({ query, lat: BASE_LAT, lng: BASE_LNG }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    expect(body).toHaveProperty("amenityPois");
+    expect(body.amenityPois.map((p: { id: string }) => p.id)).toContain(poi.id);
+
+    await prisma.amenityPOI.deleteMany({ where: { source: "test-search" } });
+  });
 });

--- a/app/tests/lib/searchResults.test.ts
+++ b/app/tests/lib/searchResults.test.ts
@@ -230,6 +230,54 @@ describe("parseSearchResultsPayload — AISearchPayload with new ParsedIntent fi
   });
 });
 
+describe("parseSearchResultsPayload — AmenitySearchPayload", () => {
+  const validAmenity = {
+    kind: "amenity-search",
+    amenityPois: [{ id: "1", lat: -33.8, lng: 151.2, name: "Test Dump Point", amenityType: { key: "dump_point" } }],
+    parsedIntent: { amenities: [], resultType: "amenities", poiTypes: ["dump_point"] },
+    query: "dump points near me",
+  };
+
+  it("accepts a valid amenity-search payload", () => {
+    const result = parseSearchResultsPayload(validAmenity);
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("amenity-search");
+  });
+
+  it("accepts an amenity-search payload with empty amenityPois array", () => {
+    const result = parseSearchResultsPayload({ ...validAmenity, amenityPois: [] });
+    expect(result).not.toBeNull();
+    expect(result?.kind).toBe("amenity-search");
+  });
+
+  it("returns null when amenityPois is missing", () => {
+    const { amenityPois: _p, ...payload } = validAmenity;
+    expect(parseSearchResultsPayload(payload)).toBeNull();
+  });
+
+  it("returns null when amenityPois is not an array", () => {
+    expect(parseSearchResultsPayload({ ...validAmenity, amenityPois: "not-an-array" })).toBeNull();
+  });
+
+  it("returns null when a POI entry is missing lat", () => {
+    expect(
+      parseSearchResultsPayload({
+        ...validAmenity,
+        amenityPois: [{ id: "1", lng: 151.2 }],
+      })
+    ).toBeNull();
+  });
+
+  it("returns null when a POI entry is missing lng", () => {
+    expect(
+      parseSearchResultsPayload({
+        ...validAmenity,
+        amenityPois: [{ id: "1", lat: -33.8 }],
+      })
+    ).toBeNull();
+  });
+});
+
 describe("parseSearchResultsPayload — invalid input", () => {
   it("returns null for null", () => {
     expect(parseSearchResultsPayload(null)).toBeNull();


### PR DESCRIPTION
## Summary

Implements issue #129 (Tasks 2 & 3 of the #120 search overhaul):

- **Task 2 — siteName DB filter**: When Claude extracts a `siteName` from the query, an `OR` clause filters campsites by `name` and `region` (case-insensitive contains). Queries like "Lane Cove campground" now narrow to the named site rather than returning everything in the bounding box.

- **Task 3 — Amenity-only routing**: When `parsedIntent.resultType === "amenities"`, the campsite pipeline is skipped entirely. The route queries `AmenityPOI` by bounding box + optional `poiTypes` and returns `{ amenityPois, parsedIntent }`. Queries like "dump points near me" now return POI results instead of campsites.

- **AmenitySearchPayload type**: Added `kind: "amenity-search"` to the `SearchResultsPayload` discriminated union in `searchResults.ts`; `parseSearchResultsPayload` validates the new kind.

- **Map.tsx guard**: Added `"amenity-search"` handling in `handleLoad` — sets POI pins from the payload without locking the map. Exposes `setSearchAmenities` from `useMapData`. Drawer rendering for amenity-only mode is deferred to #121.

## Notes

- `AmenityPOI` has no `syncStatus` field (unlike `Campsite`) so the amenity-only query does not filter by sync status.
- `siteName` filter applies _within_ the bounding box; if the named site is outside the geocoded box (e.g. user is in Melbourne, searches "Ku-ring-gai" with no location context), zero results is accepted for MVP. See issue #120 decision notes.
- `amenityHints` is captured in `ParsedIntent` but not wired to ranking in this issue (join table is empty per CLAUDE.md data notes).

## Test plan

- [x] `siteName filter: only returns campsites whose name matches siteName`
- [x] `siteName filter: returns empty campsites when no name matches within bounding box`
- [x] `amenity routing: returns amenityPois (not campsites) when resultType is 'amenities'`
- [x] `amenity routing: when resultType is 'amenities' but poiTypes is empty, returns all nearby POIs`
- [x] `AmenitySearchPayload` parser tests (6 new cases in searchResults.test.ts)
- [x] Build clean (`npm run build`)
- [ ] Manual: "Lane Cove campground" → named site in results
- [ ] Manual: "dump points near me" → amenityPois returned, not campsites
- [ ] Manual: 375px viewport — no regressions on existing browse and AI search flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)