### PR TITLE
fix(search): address PR #133 review comments

### DIFF
--- a/app/components/BottomDrawer.tsx
+++ b/app/components/BottomDrawer.tsx
@@ -410,7 +410,6 @@ function EmptySearchState({
       className="rounded-2xl p-4 text-center"
       style={{ background: SURFACE, border: `1.5px solid ${BORDER}`, boxShadow: "0 2px 12px rgba(0,0,0,0.06)" }}
     >
-      <div className="text-2xl mb-2">🏕️</div>
       <div className="text-sm font-semibold mb-1 font-[family-name:var(--font-dm-sans)]" style={{ color: FOREST_GREEN }}>
         No campsites found{location ? ` near ${location}` : ""}
       </div>
@@ -425,7 +424,7 @@ function EmptySearchState({
             className="rounded-full border border-[#e0dbd0] bg-white px-4 py-2 text-xs font-semibold font-[family-name:var(--font-dm-sans)] transition-colors hover:border-[#2d4a2d]"
             style={{ color: FOREST_GREEN }}
           >
-            Broaden search
+            Edit search
           </button>
         )}
         {onClearSearch && (
@@ -562,7 +561,7 @@ export default function BottomDrawer({
     : null;
 
   // Show empty state when the last search returned 0 results and we're not fetching
-  const showEmptyState = isEmpty && !isFetching && campsites.length === 0 && selectedPoi === null;
+  const showEmptyState = isEmpty && !isFetching && campsites.length === 0 && amenityPois.length === 0 && selectedPoi === null;
 
 
   const resultLabel =

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -14,7 +14,7 @@ import BottomDrawer, {
 } from "./BottomDrawer";
 import type { AmenityPOI, Campsite } from "@/types/map";
 import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE_OVERLAY } from "@/lib/tokens";
-import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload } from "@/lib/searchResults";
+import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload, type AmenitySearchPayload } from "@/lib/searchResults";
 import type { ParsedIntent } from "@/lib/parseIntent";
 import { getRecentSearches, addRecentSearch } from "@/lib/recentSearches";
 import { QUICK_CHIPS, AMENITY_CHIPS } from "@/lib/chips";
@@ -177,7 +177,7 @@ export default function MapView() {
   // Recent searches dropdown
   const [showRecents, setShowRecents] = useState(false);
   const [recentSearches, setRecentSearches] = useState<string[]>([]);
-  // Ref to the map search input — used by "Broaden search" to refocus it
+  // Ref to the map search input — used by "Edit search" to refocus it
   const mapSearchInputRef = useRef<HTMLInputElement>(null);
   // Wraps the search pill + recents dropdown — used to detect outside clicks
   const searchPillRef = useRef<HTMLDivElement>(null);
@@ -739,7 +739,27 @@ export default function MapView() {
         const data = (await res.json()) as { error?: string };
         throw new Error(data.error ?? "Search failed");
       }
-      const data = (await res.json()) as Pick<AISearchPayload, "campsites" | "parsedIntent">;
+      const data = (await res.json()) as
+        | Pick<AISearchPayload, "campsites" | "parsedIntent">
+        | Pick<AmenitySearchPayload, "amenityPois" | "parsedIntent">;
+
+      // Amenity-only result — route returns amenityPois instead of campsites
+      if ("amenityPois" in data) {
+        addRecentSearch(q.trim());
+        amenitySearchModeRef.current = true;
+        searchModeRef.current = false;
+        setSearchAmenities(data.amenityPois);
+        setSearchResults([]);
+        setMapQuery("");
+        setActiveChip(chipKey);
+        activeChipRef.current = chipKey;
+        setSearchContextQuery(q.trim());
+        setSearchParsedIntent(data.parsedIntent);
+        setDrawerState("half");
+        drawerStateRef.current = "half";
+        return;
+      }
+
       // Pre-populate client weather cache from search response weather so
       // loadWeatherForViewport finds all campsites already cached and skips
       // the extra round-trip to /api/weather/batch.
@@ -788,6 +808,7 @@ export default function MapView() {
       } else {
         // No results — stay in browse mode but show empty state in drawer
         searchModeRef.current = false;
+        amenitySearchModeRef.current = false;
         suppressGeoFlyRef.current = false;
         setActiveChip(null);
         activeChipRef.current = null;

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -748,7 +748,7 @@ export default function MapView() {
         addRecentSearch(q.trim());
         amenitySearchModeRef.current = data.amenityPois.length > 0;
         searchModeRef.current = false;
-        setEmptySearchResult(false);
+        setEmptySearchResult(data.amenityPois.length === 0);
         setSearchAmenities(data.amenityPois);
         setSearchResults([]);
         setMapQuery("");
@@ -756,9 +756,6 @@ export default function MapView() {
         activeChipRef.current = chipKey;
         setSearchContextQuery(q.trim());
         setSearchParsedIntent(data.parsedIntent);
-        if (data.amenityPois.length === 0) {
-          setEmptySearchResult(true);
-        }
         setDrawerState("half");
         drawerStateRef.current = "half";
         return;
@@ -816,6 +813,7 @@ export default function MapView() {
         suppressGeoFlyRef.current = false;
         setActiveChip(null);
         activeChipRef.current = null;
+        setSearchAmenities([]);
         setSearchContextQuery(q.trim());
         setSearchParsedIntent(data.parsedIntent);
         setEmptySearchResult(true);

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -746,8 +746,9 @@ export default function MapView() {
       // Amenity-only result — route returns amenityPois instead of campsites
       if ("amenityPois" in data) {
         addRecentSearch(q.trim());
-        amenitySearchModeRef.current = true;
+        amenitySearchModeRef.current = data.amenityPois.length > 0;
         searchModeRef.current = false;
+        setEmptySearchResult(false);
         setSearchAmenities(data.amenityPois);
         setSearchResults([]);
         setMapQuery("");
@@ -755,6 +756,9 @@ export default function MapView() {
         activeChipRef.current = chipKey;
         setSearchContextQuery(q.trim());
         setSearchParsedIntent(data.parsedIntent);
+        if (data.amenityPois.length === 0) {
+          setEmptySearchResult(true);
+        }
         setDrawerState("half");
         drawerStateRef.current = "half";
         return;

--- a/app/lib/recentSearches.ts
+++ b/app/lib/recentSearches.ts
@@ -14,6 +14,7 @@ export function getRecentSearches(): string[] {
 }
 
 export function addRecentSearch(query: string): void {
+  if (query.length > 200) return;
   try {
     const current = getRecentSearches();
     const deduped = [query, ...current.filter((s) => s !== query)].slice(0, MAX);


### PR DESCRIPTION
Addresses review feedback on the merged PR #133.

## Changes

**Bug fixes:**
- `handleMapSearch` now discriminates `"amenityPois" in data` before accessing `data.campsites` — previously threw `TypeError` when the API returned an amenity-only response (e.g. "dump points near me" typed in the map bar)
- Clear `amenitySearchModeRef` in the no-results campsite branch — previously left it `true` from a prior amenity search, suppressing POI pin reloads on subsequent pans
- Add `amenityPois.length === 0` to `showEmptyState` guard in `BottomDrawer`

**Code quality:**
- Remove emoji from `EmptySearchState` (CLAUDE.md: no emojis)
- Rename "Broaden search" → "Edit search" — the button focuses the input, not widen radius; label now matches behaviour
- `addRecentSearch`: ignore queries > 200 chars to prevent localStorage bloat

## Not addressed
- Hardcoded hex values in `Map.tsx` — broader refactor, deferred to a dedicated cleanup pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)