### PR TITLE
feat(search): location-based suggestions — search campsites near a city or town

### DIFF
--- a/app/.env.local.example
+++ b/app/.env.local.example
@@ -11,6 +11,9 @@ ANTHROPIC_API_KEY=
 
 # Mapbox
 NEXT_PUBLIC_MAPBOX_TOKEN=
+# Server-only token for Mapbox Geocoding API (keeps token out of client bundle).
+# Falls back to NEXT_PUBLIC_MAPBOX_TOKEN if unset. Scope to "Geocoding" read-only.
+MAPBOX_SERVER_TOKEN=
 
 # Bypasses auth so the app is testable without Google OAuth.
 # Works on Vercel Preview deployments (VERCEL_ENV=preview) and in local dev (VERCEL_ENV unset).

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -1,0 +1,82 @@
+import { prisma } from "@/lib/prisma";
+import { requireAuth } from "@/lib/apiAuth";
+import { SyncStatus } from "@/lib/generated/prisma/enums";
+
+const RESULT_LIMIT = 500;
+const DEFAULT_RADIUS_KM = 100;
+// Degrees per km at Australian latitudes (conservative overestimate for bounding box pre-filter).
+const DEG_PER_KM = 1 / 100;
+
+function haversineKm(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export async function GET(req: Request): Promise<Response> {
+  const authError = await requireAuth();
+  if (authError) return authError;
+
+  const { searchParams } = new URL(req.url);
+  const latParam = searchParams.get("lat");
+  const lngParam = searchParams.get("lng");
+  const free = searchParams.get("free") === "true";
+
+  if (latParam === null || lngParam === null) {
+    return Response.json({ error: "lat and lng are required" }, { status: 400 });
+  }
+
+  const lat = Number(latParam);
+  const lng = Number(lngParam);
+
+  if (isNaN(lat) || isNaN(lng)) {
+    return Response.json({ error: "lat and lng must be valid numbers" }, { status: 400 });
+  }
+
+  const pad = DEFAULT_RADIUS_KM * DEG_PER_KM;
+
+  try {
+    const campsites = await prisma.campsite.findMany({
+      where: {
+        syncStatus: SyncStatus.active,
+        lat: { gte: lat - pad, lte: lat + pad },
+        lng: { gte: lng - pad, lte: lng + pad },
+        ...(free && { isFree: true }),
+      },
+      select: {
+        id: true,
+        name: true,
+        lat: true,
+        lng: true,
+        region: true,
+        blurb: true,
+        amenities: {
+          select: {
+            amenityType: {
+              select: { key: true, label: true, icon: true, color: true },
+            },
+          },
+        },
+      },
+    });
+
+    const filtered = campsites
+      .map((c) => ({ c: { ...c, amenities: c.amenities.map((a) => a.amenityType) }, d: haversineKm(lat, lng, c.lat, c.lng) }))
+      .filter(({ d }) => d <= DEFAULT_RADIUS_KM)
+      .sort((a, b) => a.d - b.d);
+
+    const hasMore = filtered.length > RESULT_LIMIT;
+    const withDist = filtered.slice(0, RESULT_LIMIT);
+
+    return Response.json({ campsites: withDist.map(({ c }) => c), hasMore });
+  } catch (e) {
+    console.error("[GET /api/search/nearby]", e);
+    return Response.json({ error: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -57,6 +57,10 @@ export async function GET(req: Request): Promise<Response> {
         lng: { gte: lng - lngPad, lte: lng + lngPad },
         ...(free && { isFree: true }),
       },
+      // Safety cap: bounds memory for dense bounding boxes. At current AU data
+      // density a 200 km² box rarely exceeds ~200 rows, so 500 is conservative.
+      // If the box ever holds >500 rows, campsites beyond the cap are silently
+      // excluded before haversine filtering — acceptable for MVP scale.
       take: 500,
       select: {
         id: true,

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -42,14 +42,17 @@ export async function GET(req: Request): Promise<Response> {
     return Response.json({ error: "lat and lng must be valid coordinates" }, { status: 400 });
   }
 
-  const pad = DEFAULT_RADIUS_KM * DEG_PER_KM;
+  const latPad = DEFAULT_RADIUS_KM * DEG_PER_KM;
+  // Longitude degrees shrink with latitude (cos factor). Widen the lng window so
+  // campsites near the bounding box edge are not excluded before haversine filters them.
+  const lngPad = latPad / Math.cos((lat * Math.PI) / 180);
 
   try {
     const campsites = await prisma.campsite.findMany({
       where: {
         syncStatus: SyncStatus.active,
-        lat: { gte: lat - pad, lte: lat + pad },
-        lng: { gte: lng - pad, lte: lng + pad },
+        lat: { gte: lat - latPad, lte: lat + latPad },
+        lng: { gte: lng - lngPad, lte: lng + lngPad },
         ...(free && { isFree: true }),
       },
       select: {

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -31,6 +31,9 @@ export async function GET(req: Request): Promise<Response> {
   if (latParam === null || lngParam === null) {
     return Response.json({ error: "lat and lng are required" }, { status: 400 });
   }
+  if (latParam.trim() === "" || lngParam.trim() === "") {
+    return Response.json({ error: "lat and lng are required" }, { status: 400 });
+  }
 
   const lat = Number(latParam);
   const lng = Number(lngParam);
@@ -66,15 +69,15 @@ export async function GET(req: Request): Promise<Response> {
       },
     });
 
-    const withDist = campsites
+    const filtered = campsites
       .map((c) => ({ c: { ...c, amenities: c.amenities.map((a) => a.amenityType) }, d: haversineKm(lat, lng, c.lat, c.lng) }))
       .filter(({ d }) => d <= DEFAULT_RADIUS_KM)
-      .sort((a, b) => a.d - b.d)
-      .slice(0, RESULT_LIMIT);
+      .sort((a, b) => a.d - b.d);
 
-    const hasMore = withDist.length === RESULT_LIMIT;
+    const hasMore = filtered.length > RESULT_LIMIT;
+    const page = filtered.slice(0, RESULT_LIMIT);
 
-    return Response.json({ campsites: withDist.map(({ c }) => c), hasMore });
+    return Response.json({ campsites: page.map(({ c }) => c), hasMore });
   } catch (e) {
     console.error("[GET /api/search/nearby]", e);
     return Response.json({ error: "Internal server error" }, { status: 500 });

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -45,7 +45,9 @@ export async function GET(req: Request): Promise<Response> {
   const latPad = DEFAULT_RADIUS_KM * DEG_PER_KM;
   // Longitude degrees shrink with latitude (cos factor). Widen the lng window so
   // campsites near the bounding box edge are not excluded before haversine filters them.
-  const lngPad = latPad / Math.cos((lat * Math.PI) / 180);
+  // Cap at 180 to prevent near-pole coordinates (lat ≈ ±90) from producing a ~1e16
+  // pad that turns the DB query into a full table scan.
+  const lngPad = Math.min(latPad / Math.cos((lat * Math.PI) / 180), 180);
 
   try {
     const campsites = await prisma.campsite.findMany({

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -2,7 +2,7 @@ import { prisma } from "@/lib/prisma";
 import { requireAuth } from "@/lib/apiAuth";
 import { SyncStatus } from "@/lib/generated/prisma/enums";
 
-const RESULT_LIMIT = 500;
+const RESULT_LIMIT = 50;
 const DEFAULT_RADIUS_KM = 100;
 // Degrees per km at Australian latitudes (conservative overestimate for bounding box pre-filter).
 const DEG_PER_KM = 1 / 100;
@@ -66,13 +66,13 @@ export async function GET(req: Request): Promise<Response> {
       },
     });
 
-    const filtered = campsites
+    const withDist = campsites
       .map((c) => ({ c: { ...c, amenities: c.amenities.map((a) => a.amenityType) }, d: haversineKm(lat, lng, c.lat, c.lng) }))
       .filter(({ d }) => d <= DEFAULT_RADIUS_KM)
-      .sort((a, b) => a.d - b.d);
+      .sort((a, b) => a.d - b.d)
+      .slice(0, RESULT_LIMIT);
 
-    const hasMore = filtered.length > RESULT_LIMIT;
-    const withDist = filtered.slice(0, RESULT_LIMIT);
+    const hasMore = withDist.length === RESULT_LIMIT;
 
     return Response.json({ campsites: withDist.map(({ c }) => c), hasMore });
   } catch (e) {

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -57,6 +57,7 @@ export async function GET(req: Request): Promise<Response> {
         lng: { gte: lng - lngPad, lte: lng + lngPad },
         ...(free && { isFree: true }),
       },
+      take: 500,
       select: {
         id: true,
         name: true,

--- a/app/app/api/search/nearby/route.ts
+++ b/app/app/api/search/nearby/route.ts
@@ -38,8 +38,8 @@ export async function GET(req: Request): Promise<Response> {
   const lat = Number(latParam);
   const lng = Number(lngParam);
 
-  if (isNaN(lat) || isNaN(lng)) {
-    return Response.json({ error: "lat and lng must be valid numbers" }, { status: 400 });
+  if (!isFinite(lat) || !isFinite(lng) || lat < -90 || lat > 90 || lng < -180 || lng > 180) {
+    return Response.json({ error: "lat and lng must be valid coordinates" }, { status: 400 });
   }
 
   const pad = DEFAULT_RADIUS_KM * DEG_PER_KM;

--- a/app/app/api/search/suggestions/route.ts
+++ b/app/app/api/search/suggestions/route.ts
@@ -5,6 +5,7 @@ import { SyncStatus } from "@/lib/generated/prisma/enums";
 const MIN_QUERY_LENGTH = 2;
 const SUGGESTION_LIMIT = 4;
 const LOCATION_LIMIT = 2;
+const MAX_TOTAL_SUGGESTIONS = 7;
 
 export type CampsiteSuggestion = {
   kind: "campsite";
@@ -33,13 +34,16 @@ export type LocationSuggestion = {
 export type Suggestion = CampsiteSuggestion | RegionSuggestion | LocationSuggestion;
 
 async function fetchLocationSuggestions(q: string): Promise<LocationSuggestion[]> {
-  // TODO: use a dedicated MAPBOX_SERVER_TOKEN (no NEXT_PUBLIC_ prefix) to avoid
-  // leaking the token in server-side request logs if scope ever changes.
-  const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  // Prefer MAPBOX_SERVER_TOKEN (server-only, not in client bundle or URL logs).
+  // Fall back to NEXT_PUBLIC_MAPBOX_TOKEN for environments that only set the public var.
+  const token = process.env.MAPBOX_SERVER_TOKEN ?? process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
   if (!token) return [];
   try {
-    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?country=AU&types=place,locality,neighborhood&limit=${LOCATION_LIMIT}&access_token=${token}`;
-    const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
+    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?country=AU&types=place,locality,neighborhood&limit=${LOCATION_LIMIT}`;
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(800),
+    });
     if (!res.ok) return [];
     const data = await res.json() as { features?: Array<{ text: string; center: [number, number] }> };
     if (!Array.isArray(data.features)) return [];
@@ -98,8 +102,8 @@ export async function GET(req: Request): Promise<Response> {
       ...c,
     }));
 
-    // Locations first (city-level intent), then regions, then campsites.
-    const suggestions: Suggestion[] = [...locationSuggestions, ...regions, ...campsiteSuggestions];
+    // Locations first (city-level intent), then regions, then campsites. Cap total.
+    const suggestions: Suggestion[] = [...locationSuggestions, ...regions, ...campsiteSuggestions].slice(0, MAX_TOTAL_SUGGESTIONS);
 
     return Response.json({ suggestions });
   } catch (e) {

--- a/app/app/api/search/suggestions/route.ts
+++ b/app/app/api/search/suggestions/route.ts
@@ -3,9 +3,9 @@ import { requireAuth } from "@/lib/apiAuth";
 import { SyncStatus } from "@/lib/generated/prisma/enums";
 
 const MIN_QUERY_LENGTH = 2;
-const SUGGESTION_LIMIT = 4;
+const CAMPSITE_LIMIT = 4;
+const REGION_LIMIT = 2;
 const LOCATION_LIMIT = 2;
-const MAX_TOTAL_SUGGESTIONS = 7;
 
 export type CampsiteSuggestion = {
   kind: "campsite";
@@ -39,11 +39,10 @@ async function fetchLocationSuggestions(q: string): Promise<LocationSuggestion[]
   const token = process.env.MAPBOX_SERVER_TOKEN ?? process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
   if (!token) return [];
   try {
-    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?country=AU&types=place,locality,neighborhood&limit=${LOCATION_LIMIT}`;
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` },
-      signal: AbortSignal.timeout(800),
-    });
+    if (q.length > 200) return [];
+    // Mapbox Geocoding v5 requires the token as a query param — Bearer header is v6-only.
+    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?country=AU&types=place,locality,neighborhood&limit=${LOCATION_LIMIT}&access_token=${token}`;
+    const res = await fetch(url, { signal: AbortSignal.timeout(800) });
     if (!res.ok) return [];
     const data = await res.json() as { features?: Array<{ text: string; center: [number, number] }> };
     if (!Array.isArray(data.features)) return [];
@@ -75,7 +74,7 @@ export async function GET(req: Request): Promise<Response> {
         },
         select: { id: true, name: true, lat: true, lng: true, region: true, state: true },
         orderBy: { name: "asc" },
-        take: SUGGESTION_LIMIT,
+        take: CAMPSITE_LIMIT,
       }),
       prisma.campsite.groupBy({
         by: ["region", "state"],
@@ -85,7 +84,7 @@ export async function GET(req: Request): Promise<Response> {
         },
         _count: { region: true },
         orderBy: { _count: { region: "desc" } },
-        take: SUGGESTION_LIMIT,
+        take: REGION_LIMIT,
       }),
       fetchLocationSuggestions(q),
     ]);
@@ -102,8 +101,10 @@ export async function GET(req: Request): Promise<Response> {
       ...c,
     }));
 
-    // Locations first (city-level intent), then regions, then campsites. Cap total.
-    const suggestions: Suggestion[] = [...locationSuggestions, ...regions, ...campsiteSuggestions].slice(0, MAX_TOTAL_SUGGESTIONS);
+    // Locations first (city-level intent), then regions, then campsites.
+    // Each group is already capped at its limit by the DB/API query, so campsite
+    // results are never crowded out by a large location or region set.
+    const suggestions: Suggestion[] = [...locationSuggestions, ...regions, ...campsiteSuggestions];
 
     return Response.json({ suggestions });
   } catch (e) {

--- a/app/app/api/search/suggestions/route.ts
+++ b/app/app/api/search/suggestions/route.ts
@@ -4,6 +4,7 @@ import { SyncStatus } from "@/lib/generated/prisma/enums";
 
 const MIN_QUERY_LENGTH = 2;
 const SUGGESTION_LIMIT = 4;
+const LOCATION_LIMIT = 2;
 
 export type CampsiteSuggestion = {
   kind: "campsite";
@@ -22,7 +23,33 @@ export type RegionSuggestion = {
   state: string;
 };
 
-export type Suggestion = CampsiteSuggestion | RegionSuggestion;
+export type LocationSuggestion = {
+  kind: "location";
+  name: string;
+  lat: number;
+  lng: number;
+};
+
+export type Suggestion = CampsiteSuggestion | RegionSuggestion | LocationSuggestion;
+
+async function fetchLocationSuggestions(q: string): Promise<LocationSuggestion[]> {
+  const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  if (!token) return [];
+  try {
+    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?country=AU&types=place,locality,neighborhood&limit=${LOCATION_LIMIT}&access_token=${token}`;
+    const res = await fetch(url);
+    if (!res.ok) return [];
+    const data = await res.json() as { features: Array<{ text: string; center: [number, number] }> };
+    return data.features.map((f) => ({
+      kind: "location" as const,
+      name: f.text,
+      lat: f.center[1],
+      lng: f.center[0],
+    }));
+  } catch {
+    return [];
+  }
+}
 
 export async function GET(req: Request): Promise<Response> {
   const authError = await requireAuth();
@@ -36,7 +63,7 @@ export async function GET(req: Request): Promise<Response> {
   }
 
   try {
-    const [campsites, regionGroups] = await Promise.all([
+    const [campsites, regionGroups, locationSuggestions] = await Promise.all([
       prisma.campsite.findMany({
         where: {
           syncStatus: SyncStatus.active,
@@ -56,6 +83,7 @@ export async function GET(req: Request): Promise<Response> {
         orderBy: { _count: { region: "desc" } },
         take: SUGGESTION_LIMIT,
       }),
+      fetchLocationSuggestions(q),
     ]);
 
     const regions: RegionSuggestion[] = regionGroups.map((g) => ({
@@ -70,8 +98,8 @@ export async function GET(req: Request): Promise<Response> {
       ...c,
     }));
 
-    // Regions first, then campsites — regions are broader and more useful for navigation.
-    const suggestions: Suggestion[] = [...regions, ...campsiteSuggestions];
+    // Locations first (city-level intent), then regions, then campsites.
+    const suggestions: Suggestion[] = [...locationSuggestions, ...regions, ...campsiteSuggestions];
 
     return Response.json({ suggestions });
   } catch (e) {

--- a/app/app/api/search/suggestions/route.ts
+++ b/app/app/api/search/suggestions/route.ts
@@ -33,19 +33,19 @@ export type LocationSuggestion = {
 export type Suggestion = CampsiteSuggestion | RegionSuggestion | LocationSuggestion;
 
 async function fetchLocationSuggestions(q: string): Promise<LocationSuggestion[]> {
+  // TODO: use a dedicated MAPBOX_SERVER_TOKEN (no NEXT_PUBLIC_ prefix) to avoid
+  // leaking the token in server-side request logs if scope ever changes.
   const token = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
   if (!token) return [];
   try {
     const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?country=AU&types=place,locality,neighborhood&limit=${LOCATION_LIMIT}&access_token=${token}`;
-    const res = await fetch(url);
+    const res = await fetch(url, { signal: AbortSignal.timeout(2000) });
     if (!res.ok) return [];
-    const data = await res.json() as { features: Array<{ text: string; center: [number, number] }> };
-    return data.features.map((f) => ({
-      kind: "location" as const,
-      name: f.text,
-      lat: f.center[1],
-      lng: f.center[0],
-    }));
+    const data = await res.json() as { features?: Array<{ text: string; center: [number, number] }> };
+    if (!Array.isArray(data.features)) return [];
+    return data.features
+      .filter((f) => f.text && Array.isArray(f.center) && f.center.length >= 2)
+      .map((f) => ({ kind: "location" as const, name: f.text, lat: f.center[1], lng: f.center[0] }));
   } catch {
     return [];
   }

--- a/app/components/HomeScreen.tsx
+++ b/app/components/HomeScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useId, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { SEARCH_RESULTS_KEY, type AISearchPayload, type AmenitySearchPayload, type DirectFilterPayload, type LocationPayload, type RegionPayload, type CampsiteDirectPayload } from "@/lib/searchResults";
+import { SEARCH_RESULTS_KEY, type AISearchPayload, type AmenitySearchPayload, type DirectFilterPayload } from "@/lib/searchResults";
 import { QUICK_CHIPS } from "@/lib/chips";
 
 // Cycling placeholder prompts — matches prototype EXAMPLE_PROMPTS

--- a/app/components/HomeScreen.tsx
+++ b/app/components/HomeScreen.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useId, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import { SEARCH_RESULTS_KEY, type AISearchPayload, type AmenitySearchPayload, type DirectFilterPayload } from "@/lib/searchResults";
+import { SEARCH_RESULTS_KEY, type AISearchPayload, type AmenitySearchPayload, type DirectFilterPayload, type LocationPayload, type RegionPayload, type CampsiteDirectPayload } from "@/lib/searchResults";
 import { QUICK_CHIPS } from "@/lib/chips";
 
 // Cycling placeholder prompts — matches prototype EXAMPLE_PROMPTS

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -944,7 +944,7 @@ export default function MapView() {
         setSearchResults([]);
         setActiveChip(chipKey);
         activeChipRef.current = chipKey;
-        setSearchContextQuery(q.trim());
+        setSearchContextQuery(null);
         setSearchParsedIntent(data.parsedIntent);
         setDrawerState("half");
         drawerStateRef.current = "half";
@@ -986,7 +986,7 @@ export default function MapView() {
         };
         setActiveFilters(aiFilters);
         activeFiltersRef.current = aiFilters;
-        setSearchContextQuery(q.trim());
+        setSearchContextQuery(null);
         skipNextFetch.current = true;
         suppressGeoFlyRef.current = true;
         fitToCampsites(mapRef.current.getMap(), data.campsites, getDrawerHeightPx("half"));
@@ -1003,7 +1003,7 @@ export default function MapView() {
         setActiveChip(null);
         activeChipRef.current = null;
         setSearchAmenities([]);
-        setSearchContextQuery(q.trim());
+        setSearchContextQuery(null);
         setSearchParsedIntent(data.parsedIntent);
         setEmptySearchResult(true);
         setDrawerState("half");
@@ -1164,7 +1164,7 @@ export default function MapView() {
                 .catch(() => { /* leave the minimal seed in place */ });
             } else if (s.kind === "region") {
               void fetchRegionCampsites(s.name);
-            } else {
+            } else if (s.kind === "location") {
               // Location suggestion — fetch campsites nearby
               suppressGeoFlyRef.current = true;
               void fetchLocationCampsites(s.name, s.lat, s.lng);

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -621,6 +621,14 @@ export default function MapView() {
         return;
       }
 
+      // Location suggestion arrival — fetch campsites near the resolved coordinates.
+      if (searchPayload?.kind === "location") {
+        initialSearchRef.current = null;
+        suppressGeoFlyRef.current = true;
+        void fetchLocationCampsites(searchPayload.name, searchPayload.lat, searchPayload.lng);
+        return;
+      }
+
       // Search payload was present but returned no campsites — fall back to browse mode.
       // Reset both refs so handleMoveEnd fires normally and geolocation flyTo works.
       searchModeRef.current = false;

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -846,6 +846,29 @@ export default function MapView() {
     }
   }
 
+  // When a recent is selected, check suggestions first so location/region recents route
+  // correctly instead of falling through to NL search.
+  async function handleRecentSelect(recent: string) {
+    setMapQuery(recent);
+    setRecentSearches(getRecentSearches());
+    try {
+      const res = await fetch(`/api/search/suggestions?q=${encodeURIComponent(recent)}`);
+      if (res.ok) {
+        const { suggestions } = await res.json() as { suggestions: Suggestion[] };
+        const exactLoc = suggestions.find(
+          (s): s is Extract<Suggestion, { kind: "location" }> =>
+            s.kind === "location" && s.name.toLowerCase() === recent.toLowerCase()
+        );
+        if (exactLoc) { void fetchLocationCampsites(exactLoc.name, exactLoc.lat, exactLoc.lng); return; }
+        const exactRegion = suggestions.find(
+          (s) => s.kind === "region" && s.name.toLowerCase() === recent.toLowerCase()
+        );
+        if (exactRegion) { void fetchRegionCampsites(exactRegion.name); return; }
+      }
+    } catch { /* fall through to NL search */ }
+    void handleMapSearch(recent, null);
+  }
+
   async function fetchLocationCampsites(name: string, lat: number, lng: number) {
     setActiveChip(null);
     activeChipRef.current = null;
@@ -1173,9 +1196,7 @@ export default function MapView() {
           }}
           recentSearches={recentSearches}
           onRecentSelect={(recent) => {
-            setMapQuery(recent);
-            setRecentSearches(getRecentSearches());
-            void handleMapSearch(recent, null);
+            void handleRecentSelect(recent);
           }}
           onClear={handleClearSearch}
           loading={mapSearchLoading}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -14,7 +14,7 @@ import BottomDrawer, {
 } from "./BottomDrawer";
 import type { AmenityPOI, Campsite } from "@/types/map";
 import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE_OVERLAY } from "@/lib/tokens";
-import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload, type AmenitySearchPayload } from "@/lib/searchResults";
+import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload, type AmenitySearchPayload, type LocationPayload } from "@/lib/searchResults";
 import type { ParsedIntent } from "@/lib/parseIntent";
 import { getRecentSearches, addRecentSearch } from "@/lib/recentSearches";
 import { QUICK_CHIPS, AMENITY_CHIPS } from "@/lib/chips";
@@ -834,6 +834,44 @@ export default function MapView() {
     }
   }
 
+  async function fetchLocationCampsites(name: string, lat: number, lng: number) {
+    setActiveChip(null);
+    activeChipRef.current = null;
+    setMapSearchLoading(true);
+    setMapSearchError(null);
+    try {
+      const params = new URLSearchParams({ lat: String(lat), lng: String(lng) });
+      if (freeOnlyRef.current) params.set("free", "true");
+      const res = await fetch(`/api/search/nearby?${params}`);
+      if (!res.ok) {
+        setMapSearchError("Could not load nearby campsites. Please try again.");
+        return;
+      }
+      const data = await res.json() as { campsites: Campsite[]; hasMore: boolean };
+      setSearchResults(data.campsites);
+      setHasMore(data.hasMore);
+      searchModeRef.current = true;
+      setSearchContextQuery(name);
+      if (data.campsites.length > 0 && mapRef.current) {
+        const map = mapRef.current.getMap();
+        fitToCampsites(map, data.campsites, getDrawerHeightPx("half"));
+        setDrawerState("half");
+        drawerStateRef.current = "half";
+        loadWeatherForViewport(map, data.campsites);
+      } else {
+        setEmptySearchResult(true);
+        setDrawerState("half");
+        drawerStateRef.current = "half";
+      }
+    } catch (e) {
+      console.error("[fetchLocationCampsites]", e);
+      setMapSearchError("Could not load nearby campsites. Please try again.");
+    } finally {
+      setMapSearchLoading(false);
+      markInitialLoaded();
+    }
+  }
+
   // Inline NL search — stays on the map, replaces results without navigating home.
   async function handleMapSearch(q: string, chipKey: string | null = null) {
     if (!q.trim() || mapSearchLoading) return;
@@ -1103,8 +1141,11 @@ export default function MapView() {
                   if (mapRef.current) loadWeatherForViewport(mapRef.current.getMap(), [campsite]);
                 })
                 .catch(() => { /* leave the minimal seed in place */ });
-            } else {
+            } else if (s.kind === "region") {
               void fetchRegionCampsites(s.name);
+            } else {
+              // Location suggestion — fetch campsites nearby
+              void fetchLocationCampsites(s.name, s.lat, s.lng);
             }
           }}
           recentSearches={recentSearches}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -187,6 +187,10 @@ export default function MapView() {
   const [goodWeatherOnly, setGoodWeatherOnly] = useState(false);
   const [freeOnly, setFreeOnly] = useState(false);
   const freeOnlyRef = useRef(false);
+  // Stores the origin coords of the active location search so the Free chip can
+  // re-run fetchLocationCampsites instead of falling back to viewport browse.
+  // Cleared whenever the user exits location mode.
+  const locationCoordsRef = useRef<{ lat: number; lng: number } | null>(null);
   // Suppresses the geolocation flyTo when search results are loaded so the camera
   // doesn't pan away from the result bounds.
   // Safe today: MapView unmounts on navigation so this is never permanently stuck.
@@ -845,8 +849,10 @@ export default function MapView() {
   async function fetchLocationCampsites(name: string, lat: number, lng: number) {
     setActiveChip(null);
     activeChipRef.current = null;
+    setEmptySearchResult(false);
     setMapSearchLoading(true);
     setMapSearchError(null);
+    locationCoordsRef.current = { lat, lng };
     try {
       const params = new URLSearchParams({ lat: String(lat), lng: String(lng) });
       if (freeOnlyRef.current) params.set("free", "true");
@@ -888,6 +894,7 @@ export default function MapView() {
   // Inline NL search — stays on the map, replaces results without navigating home.
   async function handleMapSearch(q: string, chipKey: string | null = null) {
     if (!q.trim() || mapSearchLoading) return;
+    locationCoordsRef.current = null;
     // Sync the search bar to whatever query is being run — chip searches populate the bar
     // so the user always knows what was searched (mirrors HomeScreen → Map behaviour).
     setMapQuery(q);
@@ -1017,6 +1024,7 @@ export default function MapView() {
     searchModeRef.current = false;
     amenitySearchModeRef.current = false;
     suppressGeoFlyRef.current = false;
+    locationCoordsRef.current = null;
     setActiveChip(null);
     activeChipRef.current = null;
     setSearchContextQuery(null);
@@ -1225,9 +1233,12 @@ export default function MapView() {
                       const next = !freeOnly;
                       setFreeOnly(next);
                       freeOnlyRef.current = next;
-                      if (mapRef.current) {
-                        const map = mapRef.current.getMap();
-                        loadCampsites(map);
+                      const locCoords = locationCoordsRef.current;
+                      if (locCoords) {
+                        suppressGeoFlyRef.current = true;
+                        void fetchLocationCampsites(searchContextQuery ?? "", locCoords.lat, locCoords.lng);
+                      } else if (mapRef.current) {
+                        loadCampsites(mapRef.current.getMap());
                       }
                     }
                   : filterKey !== null
@@ -1417,7 +1428,7 @@ export default function MapView() {
           onSelectPin={selectPin}
           isFetching={isFetching}
           isEmpty={emptySearchResult}
-          searchLocation={searchParsedIntent?.location ?? null}
+          searchLocation={searchParsedIntent?.location ?? searchContextQuery}
           onClearSearch={handleClearSearch}
           onBroadenSearch={() => searchInputRef.current?.focus()}
         />

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -870,6 +870,11 @@ export default function MapView() {
         setEmptySearchResult(true);
         setDrawerState("half");
         drawerStateRef.current = "half";
+        // Fly to the city even when no results — keeps the map context consistent
+        // with the "near [City]" label shown in the drawer.
+        if (mapRef.current) {
+          mapRef.current.getMap().flyTo({ center: [lng, lat], zoom: 10, duration: 800 });
+        }
       }
     } catch (e) {
       console.error("[fetchLocationCampsites]", e);
@@ -1153,6 +1158,7 @@ export default function MapView() {
               void fetchRegionCampsites(s.name);
             } else {
               // Location suggestion — fetch campsites nearby
+              suppressGeoFlyRef.current = true;
               void fetchLocationCampsites(s.name, s.lat, s.lng);
             }
           }}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -884,6 +884,7 @@ export default function MapView() {
       }
     } catch (e) {
       console.error("[fetchLocationCampsites]", e);
+      locationCoordsRef.current = null;
       setMapSearchError("Could not load nearby campsites. Please try again.");
     } finally {
       setMapSearchLoading(false);

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -324,7 +324,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
                   ? s.id
                   : s.kind === "region"
                     ? `region-${s.name}`
-                    : `location-${s.name}`
+                    : `location-${s.lat}-${s.lng}`
               }
               onMouseDown={(e) => { e.preventDefault(); selectSuggestion(s); }}
               className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -333,7 +333,9 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
                 <span className="block truncate text-[11px]" style={{ color: SAGE }}>
                   {s.kind === "campsite"
                     ? [s.region, s.state].filter(Boolean).join(", ")
-                    : `Region · ${s.state} · ${s.count} campsite${s.count === 1 ? "" : "s"}`}
+                    : s.kind === "region"
+                      ? `Region · ${s.state} · ${s.count} campsite${s.count === 1 ? "" : "s"}`
+                      : "Show campsites nearby"}
                 </span>
               </span>
             </button>

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -325,7 +325,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
                   ? s.id
                   : s.kind === "region"
                     ? `region-${s.name}`
-                    : `location-${s.name}-${s.lat}`
+                    : `location-${s.name}-${s.lat}-${s.lng}`
               }
               onMouseDown={(e) => { e.preventDefault(); selectSuggestion(s); }}
               className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -70,6 +70,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
 
     debounceRef.current = setTimeout(async () => {
       if (justSelectedRef.current) {
+        justSelectedRef.current = false;
         return;
       }
       if (value.trim().length < MIN_QUERY_LENGTH) {
@@ -324,7 +325,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
                   ? s.id
                   : s.kind === "region"
                     ? `region-${s.name}`
-                    : `location-${s.lat}-${s.lng}`
+                    : `location-${s.name}-${s.lat}`
               }
               onMouseDown={(e) => { e.preventDefault(); selectSuggestion(s); }}
               className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -319,7 +319,13 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
         <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-2xl border bg-white shadow-[0_8px_24px_rgba(45,74,45,0.12)]" style={{ borderColor: BORDER }}>
           {suggestions.map((s, i) => (
             <button
-              key={s.kind === "campsite" ? s.id : `region-${s.name}`}
+              key={
+                s.kind === "campsite"
+                  ? s.id
+                  : s.kind === "region"
+                    ? `region-${s.name}`
+                    : `location-${s.name}`
+              }
               onMouseDown={(e) => { e.preventDefault(); selectSuggestion(s); }}
               className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${
                 i === highlightedIdx ? "bg-[#f0f5f0]" : "hover:bg-[#f7f5f0]"

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -70,7 +70,6 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
 
     debounceRef.current = setTimeout(async () => {
       if (justSelectedRef.current) {
-        justSelectedRef.current = false;
         return;
       }
       if (value.trim().length < MIN_QUERY_LENGTH) {
@@ -149,6 +148,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
   }
 
   function handleChange(v: string) {
+    justSelectedRef.current = false;
     onChange(v);
     if (v.trim().length >= MIN_QUERY_LENGTH) {
       setShowRecents(false);

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -55,6 +55,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
   const [showRecents, setShowRecents] = useState(false);
   const [highlightedIdx, setHighlightedIdx] = useState(-1);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const justSelectedRef = useRef(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useImperativeHandle(ref, () => ({
@@ -68,6 +69,10 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
     if (debounceRef.current) clearTimeout(debounceRef.current);
 
     debounceRef.current = setTimeout(async () => {
+      if (justSelectedRef.current) {
+        justSelectedRef.current = false;
+        return;
+      }
       if (value.trim().length < MIN_QUERY_LENGTH) {
         setSuggestions([]);
         setShowSuggestions(false);
@@ -192,6 +197,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
     setShowSuggestions(false);
     setShowRecents(false);
     setSuggestions([]);
+    justSelectedRef.current = true;
     onSuggestionSelect(s);
   }
 

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -181,10 +181,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
       e.preventDefault();
       if (highlightedIdx >= 0) {
         if (isShowingRecents) {
-          const recent = activeList[highlightedIdx] as string;
-          setShowRecents(false);
-          setHighlightedIdx(-1);
-          onRecentSelect?.(recent);
+          selectRecent(activeList[highlightedIdx] as string);
         } else {
           selectSuggestion(suggestions[highlightedIdx]);
         }
@@ -200,6 +197,13 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
     setSuggestions([]);
     justSelectedRef.current = true;
     onSuggestionSelect(s);
+  }
+
+  function selectRecent(recent: string) {
+    setShowRecents(false);
+    setHighlightedIdx(-1);
+    justSelectedRef.current = true;
+    onRecentSelect?.(recent);
   }
 
   function handleSubmit() {
@@ -358,8 +362,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
               key={recent}
               onMouseDown={(e) => {
                 e.preventDefault();
-                setShowRecents(false);
-                onRecentSelect?.(recent);
+                selectRecent(recent);
               }}
               className={`flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
                 i === highlightedIdx ? "bg-[#f0f5f0]" : "hover:bg-[#f7f5f0]"

--- a/app/lib/searchResults.ts
+++ b/app/lib/searchResults.ts
@@ -67,7 +67,7 @@ export function parseSearchResultsPayload(parsed: unknown): SearchResultsPayload
   if (obj.kind === "campsite-direct") {
     const c = obj.campsite as Record<string, unknown>;
     if (typeof c?.id !== "string" || typeof c?.name !== "string") return null;
-    if (typeof c?.lat !== "number" || typeof c?.lng !== "number") return null;
+    if (!Number.isFinite(c?.lat) || !Number.isFinite(c?.lng)) return null;
     return parsed as SearchResultsPayload;
   }
 
@@ -78,7 +78,7 @@ export function parseSearchResultsPayload(parsed: unknown): SearchResultsPayload
 
   if (obj.kind === "location") {
     if (typeof obj.name !== "string" || obj.name.trim() === "") return null;
-    if (typeof obj.lat !== "number" || typeof obj.lng !== "number") return null;
+    if (!Number.isFinite(obj.lat) || !Number.isFinite(obj.lng)) return null;
     return parsed as SearchResultsPayload;
   }
 

--- a/app/lib/searchResults.ts
+++ b/app/lib/searchResults.ts
@@ -48,7 +48,15 @@ export type RegionPayload = {
   region: string;
 };
 
-export type SearchResultsPayload = AISearchPayload | DirectFilterPayload | AmenitySearchPayload | CampsiteDirectPayload | RegionPayload;
+// Location-based proximity search — shows campsites near a geocoded city or town.
+export type LocationPayload = {
+  kind: "location";
+  name: string;
+  lat: number;
+  lng: number;
+};
+
+export type SearchResultsPayload = AISearchPayload | DirectFilterPayload | AmenitySearchPayload | CampsiteDirectPayload | RegionPayload | LocationPayload;
 
 // Parses and validates an unknown value (e.g. from JSON.parse) as a SearchResultsPayload.
 // Returns null if the shape is invalid. Exported for unit testing.
@@ -65,6 +73,12 @@ export function parseSearchResultsPayload(parsed: unknown): SearchResultsPayload
 
   if (obj.kind === "region") {
     if (typeof obj.region !== "string" || obj.region.trim() === "") return null;
+    return parsed as SearchResultsPayload;
+  }
+
+  if (obj.kind === "location") {
+    if (typeof obj.name !== "string" || obj.name.trim() === "") return null;
+    if (typeof obj.lat !== "number" || typeof obj.lng !== "number") return null;
     return parsed as SearchResultsPayload;
   }
 

--- a/app/tests/api/nearby.test.ts
+++ b/app/tests/api/nearby.test.ts
@@ -98,6 +98,7 @@ describe("GET /api/search/nearby", () => {
   it("returns hasMore: false when results are under the limit", async () => {
     const res = await GET(makeRequest(TEST_ORIGIN));
     const body = await res.json() as { campsites: unknown[]; hasMore: boolean };
+    expect(typeof body.hasMore).toBe("boolean");
     expect(body.hasMore).toBe(false);
   });
 });

--- a/app/tests/api/nearby.test.ts
+++ b/app/tests/api/nearby.test.ts
@@ -111,4 +111,26 @@ describe("GET /api/search/nearby", () => {
     expect(typeof body.hasMore).toBe("boolean");
     expect(body.hasMore).toBe(false);
   });
+
+  it("returns hasMore: true and caps results at 50 when more than 50 campsites are within range", async () => {
+    // Seed 51 campsites at ~10 km increments from TEST_ORIGIN, all well within 100 km.
+    // Offset in lat only (~1.11 km per 0.01 deg) keeps all within ~6 km.
+    const extra = Array.from({ length: 51 }, (_, i) => ({
+      name: `!Nearby Overflow ${i}`,
+      slug: `!nearby-overflow-${i}-test`,
+      lat: -29.0 + i * 0.001,
+      lng: 135.0,
+      state: "SA" as const,
+      source: TEST_SOURCE,
+      syncStatus: SyncStatus.active,
+    }));
+    await prisma.campsite.deleteMany({ where: { source: TEST_SOURCE } });
+    await prisma.campsite.createMany({ data: extra });
+
+    const res = await GET(makeRequest(TEST_ORIGIN));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { campsites: unknown[]; hasMore: boolean };
+    expect(body.hasMore).toBe(true);
+    expect(body.campsites).toHaveLength(50);
+  });
 });

--- a/app/tests/api/nearby.test.ts
+++ b/app/tests/api/nearby.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Session } from "next-auth";
+import { UserRole, SyncStatus } from "@/lib/generated/prisma/enums";
+import { prisma } from "@/lib/prisma";
+
+vi.mock("@/auth", () => ({ auth: vi.fn() }));
+
+import { auth } from "@/auth";
+import { GET } from "@/app/api/search/nearby/route";
+
+const mockAuth = vi.mocked(auth as () => Promise<Session | null>);
+
+const AUTHED_SESSION: Session = {
+  user: { id: "test-user", email: "test@example.com", name: "Test User", role: UserRole.user },
+  expires: new Date(Date.now() + 3600 * 1000).toISOString(),
+};
+
+const TEST_SOURCE = "test-nearby";
+
+function makeRequest(params: Record<string, string>) {
+  const sp = new URLSearchParams(params);
+  return new Request(`http://localhost/api/search/nearby?${sp}`);
+}
+
+beforeEach(async () => {
+  mockAuth.mockResolvedValue(AUTHED_SESSION);
+  await prisma.campsite.createMany({
+    data: [
+      // ~10 km from origin (-33.8688, 151.2093)
+      { name: "!Nearby Close", slug: "!nearby-close-test", lat: -33.78, lng: 151.18, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.active, isFree: true },
+      // ~50 km from origin
+      { name: "!Nearby Mid", slug: "!nearby-mid-test", lat: -34.28, lng: 151.0, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.active, isFree: false },
+      // ~200 km from origin — outside 100 km radius
+      { name: "!Nearby Far", slug: "!nearby-far-test", lat: -35.5, lng: 150.0, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.active },
+    ],
+  });
+});
+
+afterEach(async () => {
+  await prisma.campsite.deleteMany({ where: { source: TEST_SOURCE } });
+});
+
+describe("GET /api/search/nearby", () => {
+  it("returns 401 when unauthenticated", async () => {
+    mockAuth.mockResolvedValue(null);
+    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when lat or lng is missing", async () => {
+    const res = await GET(makeRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when lat or lng is not a valid number", async () => {
+    const res = await GET(makeRequest({ lat: "abc", lng: "151.2" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns campsites within 100 km and excludes those beyond", async () => {
+    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { campsites: Array<{ name: string }> };
+    const names = body.campsites.map((c) => c.name);
+    expect(names).toContain("!Nearby Close");
+    expect(names).toContain("!Nearby Mid");
+    expect(names).not.toContain("!Nearby Far");
+  });
+
+  it("returns campsites sorted nearest-first", async () => {
+    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    const body = await res.json() as { campsites: Array<{ name: string }> };
+    expect(body.campsites[0].name).toBe("!Nearby Close");
+  });
+
+  it("filters to isFree=true when free=true param provided", async () => {
+    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093", free: "true" }));
+    const body = await res.json() as { campsites: Array<{ name: string }> };
+    expect(body.campsites).toHaveLength(1);
+    expect(body.campsites[0].name).toBe("!Nearby Close");
+  });
+
+  it("does not return inactive campsites", async () => {
+    await prisma.campsite.create({
+      data: { name: "!Nearby Removed", slug: "!nearby-removed-test", lat: -33.78, lng: 151.18, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.removed },
+    });
+    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    const body = await res.json() as { campsites: Array<{ name: string }> };
+    expect(body.campsites.find((c) => c.name === "!Nearby Removed")).toBeUndefined();
+  });
+
+  it("returns hasMore: false when results are under the limit", async () => {
+    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    const body = await res.json() as { campsites: unknown[]; hasMore: boolean };
+    expect(body.hasMore).toBe(false);
+  });
+});

--- a/app/tests/api/nearby.test.ts
+++ b/app/tests/api/nearby.test.ts
@@ -62,6 +62,16 @@ describe("GET /api/search/nearby", () => {
     expect(res.status).toBe(400);
   });
 
+  it("returns 400 when lat or lng is Infinity", async () => {
+    const res = await GET(makeRequest({ lat: "Infinity", lng: "151.2" }));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when lat is out of range", async () => {
+    const res = await GET(makeRequest({ lat: "91", lng: "151.2" }));
+    expect(res.status).toBe(400);
+  });
+
   it("returns campsites within 100 km and excludes those beyond", async () => {
     const res = await GET(makeRequest(TEST_ORIGIN));
     expect(res.status).toBe(200);

--- a/app/tests/api/nearby.test.ts
+++ b/app/tests/api/nearby.test.ts
@@ -22,16 +22,21 @@ function makeRequest(params: Record<string, string>) {
   return new Request(`http://localhost/api/search/nearby?${sp}`);
 }
 
+// Remote outback origin with no production campsites — avoids interference from real DB data.
+// Origin: (-29.0, 135.0) — central Australia.
+// Close: ~10 km NW, Mid: ~55 km NW, Far: ~220 km away (outside 100 km radius).
+const TEST_ORIGIN = { lat: "-29.0", lng: "135.0" };
+
 beforeEach(async () => {
   mockAuth.mockResolvedValue(AUTHED_SESSION);
   await prisma.campsite.createMany({
     data: [
-      // ~10 km from origin (-33.8688, 151.2093)
-      { name: "!Nearby Close", slug: "!nearby-close-test", lat: -33.78, lng: 151.18, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.active, isFree: true },
-      // ~50 km from origin
-      { name: "!Nearby Mid", slug: "!nearby-mid-test", lat: -34.28, lng: 151.0, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.active, isFree: false },
-      // ~200 km from origin — outside 100 km radius
-      { name: "!Nearby Far", slug: "!nearby-far-test", lat: -35.5, lng: 150.0, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.active },
+      // ~10 km from TEST_ORIGIN
+      { name: "!Nearby Close", slug: "!nearby-close-test", lat: -28.91, lng: 134.91, state: "SA", source: TEST_SOURCE, syncStatus: SyncStatus.active, isFree: true },
+      // ~55 km from TEST_ORIGIN
+      { name: "!Nearby Mid", slug: "!nearby-mid-test", lat: -28.52, lng: 134.52, state: "SA", source: TEST_SOURCE, syncStatus: SyncStatus.active, isFree: false },
+      // ~220 km from TEST_ORIGIN — outside 100 km radius
+      { name: "!Nearby Far", slug: "!nearby-far-test", lat: -27.0, lng: 133.0, state: "SA", source: TEST_SOURCE, syncStatus: SyncStatus.active },
     ],
   });
 });
@@ -58,7 +63,7 @@ describe("GET /api/search/nearby", () => {
   });
 
   it("returns campsites within 100 km and excludes those beyond", async () => {
-    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    const res = await GET(makeRequest(TEST_ORIGIN));
     expect(res.status).toBe(200);
     const body = await res.json() as { campsites: Array<{ name: string }> };
     const names = body.campsites.map((c) => c.name);
@@ -68,13 +73,14 @@ describe("GET /api/search/nearby", () => {
   });
 
   it("returns campsites sorted nearest-first", async () => {
-    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    // Use !Nearby Close's exact coordinates as origin — distance 0, guaranteed first
+    const res = await GET(makeRequest({ lat: "-28.91", lng: "134.91" }));
     const body = await res.json() as { campsites: Array<{ name: string }> };
     expect(body.campsites[0].name).toBe("!Nearby Close");
   });
 
   it("filters to isFree=true when free=true param provided", async () => {
-    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093", free: "true" }));
+    const res = await GET(makeRequest({ ...TEST_ORIGIN, free: "true" }));
     const body = await res.json() as { campsites: Array<{ name: string }> };
     expect(body.campsites).toHaveLength(1);
     expect(body.campsites[0].name).toBe("!Nearby Close");
@@ -82,15 +88,15 @@ describe("GET /api/search/nearby", () => {
 
   it("does not return inactive campsites", async () => {
     await prisma.campsite.create({
-      data: { name: "!Nearby Removed", slug: "!nearby-removed-test", lat: -33.78, lng: 151.18, state: "NSW", source: TEST_SOURCE, syncStatus: SyncStatus.removed },
+      data: { name: "!Nearby Removed", slug: "!nearby-removed-test", lat: -28.91, lng: 134.91, state: "SA", source: TEST_SOURCE, syncStatus: SyncStatus.removed },
     });
-    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    const res = await GET(makeRequest(TEST_ORIGIN));
     const body = await res.json() as { campsites: Array<{ name: string }> };
     expect(body.campsites.find((c) => c.name === "!Nearby Removed")).toBeUndefined();
   });
 
   it("returns hasMore: false when results are under the limit", async () => {
-    const res = await GET(makeRequest({ lat: "-33.8688", lng: "151.2093" }));
+    const res = await GET(makeRequest(TEST_ORIGIN));
     const body = await res.json() as { campsites: unknown[]; hasMore: boolean };
     expect(body.hasMore).toBe(false);
   });

--- a/app/tests/api/suggestions.test.ts
+++ b/app/tests/api/suggestions.test.ts
@@ -23,7 +23,7 @@ function makeRequest(q: string) {
 
 beforeEach(async () => {
   mockAuth.mockResolvedValue(AUTHED_SESSION);
-  process.env.NEXT_PUBLIC_MAPBOX_TOKEN = "test-token";
+  process.env.MAPBOX_SERVER_TOKEN = "test-token";
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ features: [] }),
@@ -39,7 +39,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.unstubAllGlobals();
-  delete process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
+  delete process.env.MAPBOX_SERVER_TOKEN;
   await prisma.campsite.deleteMany({ where: { source: TEST_SOURCE } });
 });
 

--- a/app/tests/api/suggestions.test.ts
+++ b/app/tests/api/suggestions.test.ts
@@ -23,6 +23,7 @@ function makeRequest(q: string) {
 
 beforeEach(async () => {
   mockAuth.mockResolvedValue(AUTHED_SESSION);
+  process.env.NEXT_PUBLIC_MAPBOX_TOKEN = "test-token";
   vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({ features: [] }),
@@ -38,6 +39,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.unstubAllGlobals();
+  delete process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
   await prisma.campsite.deleteMany({ where: { source: TEST_SOURCE } });
 });
 

--- a/app/tests/api/suggestions.test.ts
+++ b/app/tests/api/suggestions.test.ts
@@ -23,6 +23,10 @@ function makeRequest(q: string) {
 
 beforeEach(async () => {
   mockAuth.mockResolvedValue(AUTHED_SESSION);
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({ features: [] }),
+  } as Response));
   await prisma.campsite.createMany({
     data: [
       { name: "!Blue Mountains Campsite", slug: "!blue-mountains-campsite-test", lat: -33.7, lng: 150.3, state: "NSW", region: "Blue Mountains", source: TEST_SOURCE, syncStatus: SyncStatus.active },
@@ -33,6 +37,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  vi.unstubAllGlobals();
   await prisma.campsite.deleteMany({ where: { source: TEST_SOURCE } });
 });
 
@@ -82,5 +87,34 @@ describe("GET /api/search/suggestions", () => {
     const res = await GET(makeRequest("BlueRemoved"));
     const body = await res.json() as { suggestions: Array<{ name: string }> };
     expect(body.suggestions.find((s) => s.name === "!BlueRemoved")).toBeUndefined();
+  });
+
+  it("returns location suggestions when Mapbox returns results", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        features: [{ text: "!TestCity", center: [151.0, -33.5] }],
+      }),
+    } as Response);
+    const res = await GET(makeRequest("!TestCity"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { suggestions: Array<{ kind: string; name: string; lat: number; lng: number }> };
+    const loc = body.suggestions.find((s) => s.kind === "location");
+    expect(loc).toBeDefined();
+    expect(loc?.name).toBe("!TestCity");
+    expect(typeof loc?.lat).toBe("number");
+    expect(typeof loc?.lng).toBe("number");
+  });
+
+  it("returns no location suggestions when Mapbox call fails", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+    const res = await GET(makeRequest("blue"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { suggestions: Array<{ kind: string }> };
+    expect(body.suggestions.some((s) => s.kind === "campsite" || s.kind === "region")).toBe(true);
+    expect(body.suggestions.every((s) => s.kind !== "location")).toBe(true);
   });
 });

--- a/app/tests/api/suggestions.test.ts
+++ b/app/tests/api/suggestions.test.ts
@@ -117,4 +117,12 @@ describe("GET /api/search/suggestions", () => {
     expect(body.suggestions.some((s) => s.kind === "campsite" || s.kind === "region")).toBe(true);
     expect(body.suggestions.every((s) => s.kind !== "location")).toBe(true);
   });
+
+  it("returns other suggestions when Mapbox fetch throws", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network"));
+    const res = await GET(makeRequest("blue"));
+    expect(res.status).toBe(200);
+    const body = await res.json() as { suggestions: Array<{ kind: string }> };
+    expect(body.suggestions.every((s) => s.kind !== "location")).toBe(true);
+  });
 });

--- a/docs/regression-checklist-map.md
+++ b/docs/regression-checklist-map.md
@@ -52,7 +52,8 @@ Run this before merging any PR that touches Map.tsx, BottomDrawer.tsx, SearchInp
 
 ## 6. Context label
 
-- [ ] There is **no** visible context label below the search bar in normal use — the label only appears if `searchContextQuery` is set while the bar is empty, which does not occur in the current UI flows
+- [ ] In normal browse mode (no active search), there is **no** context label below the search bar
+- [ ] After selecting a **location suggestion** (city/town), the drawer shows the city name as the search context (e.g. "near Melbourne") in the empty-state message — see §11a and §12 for full location search checks
 
 ---
 

--- a/docs/regression-checklist-map.md
+++ b/docs/regression-checklist-map.md
@@ -1,0 +1,156 @@
+# Map Screen Regression Checklist
+
+Run this before merging any PR that touches Map.tsx, BottomDrawer.tsx, SearchInput.tsx, HomeScreen.tsx, or any `/api/search/*` route.
+
+---
+
+## 1. HomeScreen appearance
+
+- [ ] Search card shows a **textarea** (multiline, 3 rows), not a single-line input
+- [ ] `Try: "not raining this weekend"` hint is visible at the bottom-left of the card
+- [ ] **Pitch** button at the bottom-right of the card; greyed out when textarea is empty, coral when text is present
+- [ ] Placeholder text cycles through the four example prompts
+- [ ] Suggested prompts list is visible below the search card
+- [ ] Tapping a suggested prompt populates the textarea
+- [ ] Quick-filter chips (Pitchd, Good weather, Dog friendly, etc.) are visible and tappable
+
+---
+
+## 2. HomeScreen → Map navigation
+
+- [ ] Typing a query and tapping **Pitch** navigates to the map and the **map search bar** shows the exact same query
+- [ ] Tapping the **Pitchd** chip on the HomeScreen navigates to the map; the map search bar shows the Pitchd chip's query and the Pitchd chip is highlighted
+- [ ] Tapping the **Good weather** chip navigates to the map; the map loads with the Good weather filter active (no search bar query)
+
+---
+
+## 3. Map search bar — basic behaviour
+
+- [ ] Search bar is visible at the top of the map in pill style (white, rounded-full)
+- [ ] Typing in the bar and pressing Search runs a search; the query stays in the bar after results load
+- [ ] The circular button shows a **search icon** when the bar is empty / loading; shows an **× button** when the bar has text (and is not loading)
+- [ ] Tapping **×** clears the bar, clears results, and returns to browse mode
+
+---
+
+## 4. Chip searches populate the search bar
+
+- [ ] Tapping **Pitchd** chip on the map populates the bar with the Pitchd query and runs the search
+- [ ] Tapping **Dog friendly** chip on the map populates the bar with that chip's query
+- [ ] After a chip search, the bar shows the chip's query (not empty)
+
+---
+
+## 5. Chip active / disabled state
+
+- [ ] After a **bar** (NL) search, **no chip is highlighted**
+- [ ] After a **Pitchd chip** search, only the Pitchd chip is highlighted
+- [ ] While a chip search is loading, **only that chip** is visually disabled; other chips remain tappable
+- [ ] Bar searches during load do **not** disable any chip
+
+---
+
+## 6. Context label
+
+- [ ] There is **no** visible context label below the search bar in normal use — the label only appears if `searchContextQuery` is set while the bar is empty, which does not occur in the current UI flows
+
+---
+
+## 7. Drawer states
+
+- [ ] Drawer is visible in **peek** state (64 px strip) on page load
+- [ ] Swiping up / tapping **▲ More** expands to **half** state
+- [ ] Tapping **▲ More** again expands to **full** state
+- [ ] Tapping **▼ Less** collapses from full directly back to **peek**
+- [ ] Dragging the handle pill moves the drawer smoothly between states
+- [ ] In **full** state the card list scrolls independently of the map (no accidental drawer drag while scrolling)
+
+---
+
+## 8. Search input focusability (Radix FocusScope fix)
+
+- [ ] Tapping the search bar while drawer is in **peek** state — input becomes focused, keyboard appears
+- [ ] Tapping the search bar while drawer is in **half** state — input becomes focused, keyboard appears
+- [ ] Tapping the search bar while drawer is in **full** state — input becomes focused, keyboard appears
+- [ ] Typing a character while drawer is full collapses drawer to **peek** automatically
+- [ ] The circular action button does **not** steal focus when the drawer is opened
+
+---
+
+## 9. Soft keyboard — drawer stability (critical mobile regression)
+
+- [ ] Tap search input → keyboard opens → **drawer remains visible** at peek strip
+- [ ] Dismiss keyboard (tap Done / back / outside input) → **drawer is still visible** at the same snap position it was before
+- [ ] After dismissing keyboard, tapping the drawer handle or map still responds normally
+- [ ] Repeat the above with drawer in **half** state before tapping input
+
+---
+
+## 10. Recent searches
+
+- [ ] After running a search, the query is saved to recents
+- [ ] Tapping the search bar when it is empty / short shows the recents dropdown
+- [ ] Selecting a recent populates the bar **and** runs the search
+- [ ] Keyboard up/down navigates the recents list; Enter selects
+
+---
+
+## 11. Suggestion dropdown — campsite & region
+
+- [ ] Typing ≥2 characters shows the suggestions dropdown
+- [ ] **Campsite** suggestions show ⛺ icon with state below; clicking navigates to that pin on the map
+- [ ] **Region** suggestions show 📍 icon with "Region · state · N campsites" below; clicking loads campsites in that region
+- [ ] After clicking a suggestion the **dropdown closes and does not reopen** (no 300 ms flicker)
+- [ ] Pressing Escape dismisses the dropdown without searching
+- [ ] Clicking/tapping outside the search bar dismisses the dropdown
+
+---
+
+## 11a. Suggestion dropdown — city & town (location search)
+
+- [ ] Typing a **city name** (e.g. "Sydney", "Melbourne", "Cairns") shows 📍 location suggestions at the **top** of the dropdown, above any region/campsite results
+- [ ] Location suggestions show the subtitle **"Show campsites nearby"**
+- [ ] Clicking a **location suggestion** flies the map to that city and loads campsites within 100 km, sorted by proximity
+- [ ] The search bar shows the city name after selection (e.g. "Sydney")
+- [ ] The context label below the bar shows the city name (e.g. "Sydney") with **✕ Browse area**
+- [ ] Typing a **town name** (e.g. "Jindabyne", "Cooma", "Bright") also returns location suggestions
+- [ ] Typing a **suburb name** (e.g. "Manly", "St Kilda") returns location suggestions
+- [ ] If no city/town matches, no location suggestions appear — campsite/region results are unaffected
+- [ ] Location suggestions do **not** appear for very short queries (< 2 chars)
+- [ ] When Mapbox returns two places with the **same name** (e.g. two "Manly" suburbs), both rows appear without React key warnings — **0 console errors**
+
+---
+
+## 11b. Region search (via region suggestion)
+
+- [ ] Typing a known region name (e.g. "Blue Mountains", "Snowy Mountains") shows a region suggestion when region data is populated in DB
+- [ ] Clicking a region suggestion shows all campsites in that region sorted by proximity to user location
+- [ ] The drawer count shows "X campsites found" for the region
+
+---
+
+## 12. Proximity search results (nearby)
+
+- [ ] After selecting a city suggestion, the map **flies to the city centre** (not the user's GPS location)
+- [ ] Campsites within 100 km are shown; campsites beyond 100 km are excluded
+- [ ] Results are sorted **nearest-first** (closest campsite is at the top of the drawer list)
+- [ ] The **Free** chip applies on top of a proximity search (re-fetches with `free=true`)
+- [ ] Tapping **✕ Browse area** exits proximity search and returns to browse mode
+- [ ] If no campsites exist within 100 km, the drawer shows the **empty state** (not a crash)
+
+---
+
+## 13. Browse mode (no search)
+
+- [ ] On load without a search payload, map shows pins for the default area
+- [ ] Drawer shows "X campsites found" (or fetching spinner)
+- [ ] Tapping a pin highlights it and shows it in the peek strip
+
+---
+
+## Environment
+
+Tested on:
+- Desktop Chrome (Playwright / devtools mobile simulation)
+- Real iOS Safari (manual)
+- Real Android Chrome (manual)

--- a/docs/regression-checklist-map.md
+++ b/docs/regression-checklist-map.md
@@ -124,7 +124,7 @@ Run this before merging any PR that touches Map.tsx, BottomDrawer.tsx, SearchInp
 ## 11b. Region search (via region suggestion)
 
 - [ ] Typing a known region name (e.g. "Blue Mountains", "Snowy Mountains") shows a region suggestion when region data is populated in DB
-- [ ] Clicking a region suggestion shows all campsites in that region sorted by proximity to user location
+- [ ] Clicking a region suggestion shows all campsites in that region sorted by proximity to the region centre
 - [ ] The drawer count shows "X campsites found" for the region
 
 ---


### PR DESCRIPTION
## Summary

- Adds `kind: \"location\"` suggestions to the search dropdown — typing a city, town, or suburb (e.g. \"Sydney\", \"Jindabyne\", \"Manly\") now shows 📍 geocoded suggestions at the top, powered by the Mapbox Geocoding API
- New `GET /api/search/nearby` endpoint returns campsites within 100 km of a lat/lng, sorted by proximity; respects the `free=true` filter
- Adds `LocationPayload` to `searchResults.ts` so both the map search bar and future HomeScreen wiring can navigate to a proximity search
- Fixes a pre-existing bug: suggestion dropdown was re-opening ~300ms after selection due to a debounce re-trigger

## What changed

| File | Change |
|---|---|
| `app/api/search/suggestions/route.ts` | Added `LocationSuggestion` type; calls Mapbox v5 geocoding API in parallel with DB queries; graceful degradation (empty array on any failure), 2s timeout |
| `app/api/search/nearby/route.ts` | New endpoint — bounding-box DB pre-filter + haversine post-filter, sorted, sliced to 50, `hasMore` flag |
| `app/lib/searchResults.ts` | Added `LocationPayload` type + parse branch |
| `app/components/SearchInput.tsx` | Three-way dropdown subtitle (campsite/region/location); `justSelectedRef` debounce guard; lat/lng-keyed location rows |
| `app/components/Map.tsx` | `fetchLocationCampsites` function; `handleLoad` location branch; location arm in `onSuggestionSelect` |
| `docs/regression-checklist-map.md` | Added §11a (city/town suggestions), §11b (region), §12 (proximity results) |

## Test plan

- [ ] Type "Sydney" in map search bar → 📍 Sydney suggestion appears at top with "Show campsites nearby"
- [ ] Click suggestion → map flies to Sydney, drawer shows campsites within 100 km sorted nearest-first
- [ ] Type "Jindabyne" → town suggestion appears and loads nearby campsites
- [ ] Type "Manly" → two Manly suggestions render with no console errors (duplicate-name fix)
- [ ] Click × → clears results and returns to browse mode
- [ ] `npm test` → 288 passing

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)