### PR TITLE
fix(search): recents routing — campsite names navigate to site, not proximity search

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -846,8 +846,8 @@ export default function MapView() {
     }
   }
 
-  // When a recent is selected, check suggestions first so location/region recents route
-  // correctly instead of falling through to NL search.
+  // When a recent is selected, check suggestions first so the same action that originally
+  // produced the result is replicated. Priority: campsite (most specific) → region → location → NL.
   async function handleRecentSelect(recent: string) {
     setMapQuery(recent);
     setRecentSearches(getRecentSearches());
@@ -855,15 +855,44 @@ export default function MapView() {
       const res = await fetch(`/api/search/suggestions?q=${encodeURIComponent(recent)}`);
       if (res.ok) {
         const { suggestions } = await res.json() as { suggestions: Suggestion[] };
-        const exactLoc = suggestions.find(
-          (s): s is Extract<Suggestion, { kind: "location" }> =>
-            s.kind === "location" && s.name.toLowerCase() === recent.toLowerCase()
+        const lc = recent.toLowerCase();
+
+        // Campsite exact match — seed pin and fly to it, same as suggestion selection.
+        const exactCampsite = suggestions.find(
+          (s): s is Extract<Suggestion, { kind: "campsite" }> =>
+            s.kind === "campsite" && s.name.toLowerCase() === lc
         );
-        if (exactLoc) { void fetchLocationCampsites(exactLoc.name, exactLoc.lat, exactLoc.lng); return; }
+        if (exactCampsite) {
+          const s = exactCampsite;
+          setSearchResults([{ id: s.id, name: s.name, lat: s.lat, lng: s.lng, region: s.region ?? null, blurb: null, amenities: [], weather: null }]);
+          mapRef.current?.getMap().flyTo({ center: [s.lng, s.lat], zoom: 14, duration: 800 });
+          setDrawerState("peek");
+          drawerStateRef.current = "peek";
+          searchModeRef.current = true;
+          suppressGeoFlyRef.current = true;
+          setSearchContextQuery(s.name);
+          fetch(`/api/campsites/${s.id}`)
+            .then((r) => r.ok ? r.json() : null)
+            .then((full: { id: string; name: string; lat: number; lng: number; region: string | null; blurb: string | null; amenities: { key: string; label: string; icon: string; color: string }[] } | null) => {
+              if (!full) return;
+              const campsite = { ...full, weather: null };
+              setSearchResults([campsite]);
+              if (mapRef.current) loadWeatherForViewport(mapRef.current.getMap(), [campsite]);
+            })
+            .catch(() => { /* leave the minimal seed in place */ });
+          return;
+        }
+
         const exactRegion = suggestions.find(
-          (s) => s.kind === "region" && s.name.toLowerCase() === recent.toLowerCase()
+          (s) => s.kind === "region" && s.name.toLowerCase() === lc
         );
         if (exactRegion) { void fetchRegionCampsites(exactRegion.name); return; }
+
+        const exactLoc = suggestions.find(
+          (s): s is Extract<Suggestion, { kind: "location" }> =>
+            s.kind === "location" && s.name.toLowerCase() === lc
+        );
+        if (exactLoc) { void fetchLocationCampsites(exactLoc.name, exactLoc.lat, exactLoc.lng); return; }
       }
     } catch { /* fall through to NL search */ }
     void handleMapSearch(recent, null);

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -16,7 +16,7 @@ import type { AmenityPOI, Campsite } from "@/types/map";
 import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE_OVERLAY } from "@/lib/tokens";
 import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload, type AmenitySearchPayload, type LocationPayload } from "@/lib/searchResults";
 import type { ParsedIntent } from "@/lib/parseIntent";
-import { getRecentSearches, addRecentSearch } from "@/lib/recentSearches";
+import { getRecentEntries, addRecentEntry, type RecentEntry } from "@/lib/recentSearches";
 import { QUICK_CHIPS, AMENITY_CHIPS } from "@/lib/chips";
 import { CampsitePin } from "./CampsitePin";
 import { AmenityPin, type AmenityPinMeta } from "./AmenityPin";
@@ -177,7 +177,7 @@ export default function MapView() {
       : ""
   );
   // Recent searches — loaded on mount and refreshed after each search for the SearchInput dropdown
-  const [recentSearches, setRecentSearches] = useState<string[]>([]);
+  const [recentSearches, setRecentSearches] = useState<RecentEntry[]>([]);
   // Ref to the SearchInput — used to restore focus after Vaul steals it
   const searchInputRef = useRef<SearchInputHandle>(null);
   // Blur timeout ref — used in cleanup to cancel any pending blur timer
@@ -472,7 +472,7 @@ export default function MapView() {
 
   // Load recent searches once on mount so SearchInput can show them immediately on focus.
   useEffect(() => {
-    setRecentSearches(getRecentSearches());
+    setRecentSearches(getRecentEntries());
   }, []);
 
   // Prevent Radix's FocusScope (inside Vaul's Drawer.Content) from stealing keyboard
@@ -846,56 +846,33 @@ export default function MapView() {
     }
   }
 
-  // When a recent is selected, check suggestions first so the same action that originally
-  // produced the result is replicated. Priority: campsite (most specific) → region → location → NL.
-  async function handleRecentSelect(recent: string) {
-    setMapQuery(recent);
-    setRecentSearches(getRecentSearches());
-    try {
-      const res = await fetch(`/api/search/suggestions?q=${encodeURIComponent(recent)}`);
-      if (res.ok) {
-        const { suggestions } = await res.json() as { suggestions: Suggestion[] };
-        const lc = recent.toLowerCase();
-
-        // Campsite exact match — seed pin and fly to it, same as suggestion selection.
-        const exactCampsite = suggestions.find(
-          (s): s is Extract<Suggestion, { kind: "campsite" }> =>
-            s.kind === "campsite" && s.name.toLowerCase() === lc
-        );
-        if (exactCampsite) {
-          const s = exactCampsite;
-          setSearchResults([{ id: s.id, name: s.name, lat: s.lat, lng: s.lng, region: s.region ?? null, blurb: null, amenities: [], weather: null }]);
-          mapRef.current?.getMap().flyTo({ center: [s.lng, s.lat], zoom: 14, duration: 800 });
-          setDrawerState("peek");
-          drawerStateRef.current = "peek";
-          searchModeRef.current = true;
-          suppressGeoFlyRef.current = true;
-          setSearchContextQuery(s.name);
-          fetch(`/api/campsites/${s.id}`)
-            .then((r) => r.ok ? r.json() : null)
-            .then((full: { id: string; name: string; lat: number; lng: number; region: string | null; blurb: string | null; amenities: { key: string; label: string; icon: string; color: string }[] } | null) => {
-              if (!full) return;
-              const campsite = { ...full, weather: null };
-              setSearchResults([campsite]);
-              if (mapRef.current) loadWeatherForViewport(mapRef.current.getMap(), [campsite]);
-            })
-            .catch(() => { /* leave the minimal seed in place */ });
-          return;
-        }
-
-        const exactRegion = suggestions.find(
-          (s) => s.kind === "region" && s.name.toLowerCase() === lc
-        );
-        if (exactRegion) { void fetchRegionCampsites(exactRegion.name); return; }
-
-        const exactLoc = suggestions.find(
-          (s): s is Extract<Suggestion, { kind: "location" }> =>
-            s.kind === "location" && s.name.toLowerCase() === lc
-        );
-        if (exactLoc) { void fetchLocationCampsites(exactLoc.name, exactLoc.lat, exactLoc.lng); return; }
-      }
-    } catch { /* fall through to NL search */ }
-    void handleMapSearch(recent, null);
+  function handleRecentSelect(entry: RecentEntry) {
+    setMapQuery(entry.name);
+    setRecentSearches(getRecentEntries());
+    if (entry.kind === "campsite") {
+      setSearchResults([{ id: entry.id, name: entry.name, lat: entry.lat, lng: entry.lng, region: entry.region, blurb: null, amenities: [], weather: null }]);
+      mapRef.current?.getMap().flyTo({ center: [entry.lng, entry.lat], zoom: 14, duration: 800 });
+      setDrawerState("peek");
+      drawerStateRef.current = "peek";
+      searchModeRef.current = true;
+      suppressGeoFlyRef.current = true;
+      setSearchContextQuery(entry.name);
+      fetch(`/api/campsites/${entry.id}`)
+        .then((r) => r.ok ? r.json() : null)
+        .then((full: { id: string; name: string; lat: number; lng: number; region: string | null; blurb: string | null; amenities: { key: string; label: string; icon: string; color: string }[] } | null) => {
+          if (!full) return;
+          const campsite = { ...full, weather: null };
+          setSearchResults([campsite]);
+          if (mapRef.current) loadWeatherForViewport(mapRef.current.getMap(), [campsite]);
+        })
+        .catch(() => { /* leave the minimal seed in place */ });
+    } else if (entry.kind === "region") {
+      void fetchRegionCampsites(entry.name);
+    } else if (entry.kind === "location") {
+      void fetchLocationCampsites(entry.name, entry.lat, entry.lng);
+    } else {
+      void handleMapSearch(entry.name, null);
+    }
   }
 
   async function fetchLocationCampsites(name: string, lat: number, lng: number) {
@@ -989,7 +966,7 @@ export default function MapView() {
 
       // Amenity-only result — route returns amenityPois instead of campsites
       if ("amenityPois" in data) {
-        addRecentSearch(q.trim());
+        addRecentEntry({ kind: "nl", name: q.trim() });
         amenitySearchModeRef.current = data.amenityPois.length > 0;
         searchModeRef.current = false;
         setEmptySearchResult(data.amenityPois.length === 0);
@@ -1012,7 +989,7 @@ export default function MapView() {
           weatherCacheRef.current.set(c.id, c.weather);
         }
       }
-      addRecentSearch(q.trim());
+      addRecentEntry({ kind: "nl", name: q.trim() });
       setSearchResults(data.campsites);
       if (data.campsites.length > 0 && mapRef.current) {
         // Results — enter search mode and fit the map to the pins
@@ -1193,8 +1170,14 @@ export default function MapView() {
             setGoodWeatherOnly(false);
             setFreeOnly(false);
             freeOnlyRef.current = false;
-            addRecentSearch(s.name);
-            setRecentSearches(getRecentSearches());
+            if (s.kind === "campsite") {
+              addRecentEntry({ kind: "campsite", name: s.name, id: s.id, lat: s.lat, lng: s.lng, region: s.region ?? null });
+            } else if (s.kind === "region") {
+              addRecentEntry({ kind: "region", name: s.name });
+            } else {
+              addRecentEntry({ kind: "location", name: s.name, lat: s.lat, lng: s.lng });
+            }
+            setRecentSearches(getRecentEntries());
             setMapQuery(s.name);
             if (s.kind === "campsite") {
               // Seed immediately with minimal data so the pin appears without delay,
@@ -1224,9 +1207,7 @@ export default function MapView() {
             }
           }}
           recentSearches={recentSearches}
-          onRecentSelect={(recent) => {
-            void handleRecentSelect(recent);
-          }}
+          onRecentSelect={(entry) => { handleRecentSelect(entry); }}
           onClear={handleClearSearch}
           loading={mapSearchLoading}
           placeholder="Site name, area, or describe your trip…"

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -849,6 +849,13 @@ export default function MapView() {
   function handleRecentSelect(entry: RecentEntry) {
     setMapQuery(entry.name);
     setRecentSearches(getRecentEntries());
+    setActiveChip(null);
+    activeChipRef.current = null;
+    setHasMore(false);
+    setEmptySearchResult(false);
+    setGoodWeatherOnly(false);
+    setFreeOnly(false);
+    freeOnlyRef.current = false;
     if (entry.kind === "campsite") {
       setSearchResults([{ id: entry.id, name: entry.name, lat: entry.lat, lng: entry.lng, region: entry.region, blurb: null, amenities: [], weather: null }]);
       mapRef.current?.getMap().flyTo({ center: [entry.lng, entry.lat], zoom: 14, duration: 800 });
@@ -859,7 +866,7 @@ export default function MapView() {
       setSearchContextQuery(entry.name);
       fetch(`/api/campsites/${entry.id}`)
         .then((r) => r.ok ? r.json() : null)
-        .then((full: { id: string; name: string; lat: number; lng: number; region: string | null; blurb: string | null; amenities: { key: string; label: string; icon: string; color: string }[] } | null) => {
+        .then((full: Campsite | null) => {
           if (!full) return;
           const campsite = { ...full, weather: null };
           setSearchResults([campsite]);
@@ -1191,7 +1198,7 @@ export default function MapView() {
               setSearchContextQuery(s.name);
               fetch(`/api/campsites/${s.id}`)
                 .then((r) => r.ok ? r.json() : null)
-                .then((full: { id: string; name: string; lat: number; lng: number; region: string | null; blurb: string | null; amenities: { key: string; label: string; icon: string; color: string }[] } | null) => {
+                .then((full: Campsite | null) => {
                   if (!full) return;
                   const campsite = { ...full, weather: null };
                   setSearchResults([campsite]);

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -857,6 +857,8 @@ export default function MapView() {
     setFreeOnly(false);
     freeOnlyRef.current = false;
     if (entry.kind === "campsite") {
+      locationCoordsRef.current = null;
+      setMapSearchError(null);
       setSearchResults([{ id: entry.id, name: entry.name, lat: entry.lat, lng: entry.lng, region: entry.region, blurb: null, amenities: [], weather: null }]);
       mapRef.current?.getMap().flyTo({ center: [entry.lng, entry.lat], zoom: 14, duration: 800 });
       setDrawerState("peek");

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -360,7 +360,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
         <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-2xl border bg-white shadow-[0_8px_24px_rgba(45,74,45,0.12)]" style={{ borderColor: BORDER }}>
           {recentSearches.map((entry, i) => (
             <button
-              key={entry.name}
+              key={entry.kind === "campsite" ? entry.id : entry.name}
               onMouseDown={(e) => {
                 e.preventDefault();
                 selectRecent(entry);

--- a/app/components/SearchInput.tsx
+++ b/app/components/SearchInput.tsx
@@ -2,6 +2,7 @@
 
 import React, { useEffect, useImperativeHandle, useRef, useState } from "react";
 import type { Suggestion } from "@/app/api/search/suggestions/route";
+import type { RecentEntry } from "@/lib/recentSearches";
 import { BORDER, CORAL, FOREST_GREEN, SAGE, TEXT, TEXT_MUTED } from "@/lib/tokens";
 
 export type { Suggestion };
@@ -11,8 +12,8 @@ interface SearchInputProps {
   onChange: (v: string) => void;
   onSearch: (query: string) => void;
   onSuggestionSelect: (suggestion: Suggestion) => void;
-  recentSearches?: string[];
-  onRecentSelect?: (query: string) => void;
+  recentSearches?: RecentEntry[];
+  onRecentSelect?: (entry: RecentEntry) => void;
   placeholder?: string;
   loading?: boolean;
   /** "pill" renders the original map search bar style (white rounded-full, circular icon button).
@@ -181,7 +182,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
       e.preventDefault();
       if (highlightedIdx >= 0) {
         if (isShowingRecents) {
-          selectRecent(activeList[highlightedIdx] as string);
+          selectRecent(activeList[highlightedIdx] as RecentEntry);
         } else {
           selectSuggestion(suggestions[highlightedIdx]);
         }
@@ -199,11 +200,11 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
     onSuggestionSelect(s);
   }
 
-  function selectRecent(recent: string) {
+  function selectRecent(entry: RecentEntry) {
     setShowRecents(false);
     setHighlightedIdx(-1);
     justSelectedRef.current = true;
-    onRecentSelect?.(recent);
+    onRecentSelect?.(entry);
   }
 
   function handleSubmit() {
@@ -357,12 +358,12 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
       {/* Recents dropdown (map bar only — shown when input is empty/short) */}
       {showRecents && !showSuggestions && recentSearches && recentSearches.length > 0 && (
         <div className="absolute left-0 right-0 top-full z-50 mt-1.5 overflow-hidden rounded-2xl border bg-white shadow-[0_8px_24px_rgba(45,74,45,0.12)]" style={{ borderColor: BORDER }}>
-          {recentSearches.map((recent, i) => (
+          {recentSearches.map((entry, i) => (
             <button
-              key={recent}
+              key={entry.name}
               onMouseDown={(e) => {
                 e.preventDefault();
-                selectRecent(recent);
+                selectRecent(entry);
               }}
               className={`flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
                 i === highlightedIdx ? "bg-[#f0f5f0]" : "hover:bg-[#f7f5f0]"
@@ -372,7 +373,7 @@ const SearchInput = React.forwardRef<SearchInputHandle, SearchInputProps>(functi
               style={{ color: TEXT }}
             >
               <span style={{ color: SAGE }}>🕐</span>
-              <span className="flex-1 truncate">{recent}</span>
+              <span className="flex-1 truncate">{entry.name}</span>
             </button>
           ))}
         </div>

--- a/app/lib/recentSearches.ts
+++ b/app/lib/recentSearches.ts
@@ -14,7 +14,8 @@ function parseEntry(raw: unknown): RecentEntry | null {
   const o = raw as Record<string, unknown>;
   if (o.kind === "nl"       && typeof o.name === "string") return o as RecentEntry;
   if (o.kind === "campsite" && typeof o.name === "string" && typeof o.id === "string"
-      && typeof o.lat === "number" && typeof o.lng === "number") return o as RecentEntry;
+      && typeof o.lat === "number" && typeof o.lng === "number"
+      && (o.region === null || typeof o.region === "string")) return o as RecentEntry;
   if (o.kind === "location" && typeof o.name === "string"
       && typeof o.lat === "number" && typeof o.lng === "number") return o as RecentEntry;
   if (o.kind === "region"   && typeof o.name === "string") return o as RecentEntry;

--- a/app/lib/recentSearches.ts
+++ b/app/lib/recentSearches.ts
@@ -1,24 +1,44 @@
 const KEY = "pitchd:recentSearches";
 const MAX = 5;
 
-export function getRecentSearches(): string[] {
+export type RecentEntry =
+  | { kind: "nl";       name: string }
+  | { kind: "campsite"; name: string; id: string; lat: number; lng: number; region: string | null }
+  | { kind: "location"; name: string; lat: number; lng: number }
+  | { kind: "region";   name: string };
+
+function parseEntry(raw: unknown): RecentEntry | null {
+  // Migrate legacy plain-string entries (stored before typed recents).
+  if (typeof raw === "string") return { kind: "nl", name: raw };
+  if (typeof raw !== "object" || raw === null) return null;
+  const o = raw as Record<string, unknown>;
+  if (o.kind === "nl"       && typeof o.name === "string") return o as RecentEntry;
+  if (o.kind === "campsite" && typeof o.name === "string" && typeof o.id === "string"
+      && typeof o.lat === "number" && typeof o.lng === "number") return o as RecentEntry;
+  if (o.kind === "location" && typeof o.name === "string"
+      && typeof o.lat === "number" && typeof o.lng === "number") return o as RecentEntry;
+  if (o.kind === "region"   && typeof o.name === "string") return o as RecentEntry;
+  return null;
+}
+
+export function getRecentEntries(): RecentEntry[] {
   try {
     const raw = localStorage.getItem(KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter((s): s is string => typeof s === "string").slice(0, MAX);
+    return parsed.map(parseEntry).filter((e): e is RecentEntry => e !== null).slice(0, MAX);
   } catch {
     return [];
   }
 }
 
-export function addRecentSearch(query: string): void {
-  if (query.length > 200) return;
+export function addRecentEntry(entry: RecentEntry): void {
+  if (entry.name.length > 200) return;
   try {
-    const current = getRecentSearches();
-    const deduped = [query, ...current.filter((s) => s !== query)].slice(0, MAX);
-    localStorage.setItem(KEY, JSON.stringify(deduped));
+    // Deduplicate by name so re-searching the same place replaces the old entry.
+    const current = getRecentEntries().filter((e) => e.name !== entry.name);
+    localStorage.setItem(KEY, JSON.stringify([entry, ...current].slice(0, MAX)));
   } catch {
     // localStorage unavailable or full — fail silently
   }

--- a/app/lib/recentSearches.ts
+++ b/app/lib/recentSearches.ts
@@ -37,8 +37,13 @@ export function getRecentEntries(): RecentEntry[] {
 export function addRecentEntry(entry: RecentEntry): void {
   if (entry.name.length > 200) return;
   try {
-    // Deduplicate by name so re-searching the same place replaces the old entry.
-    const current = getRecentEntries().filter((e) => e.name !== entry.name);
+    // Deduplicate by kind+id (campsite) or kind+name so different kinds with the same
+    // display name (e.g. campsite "Blue Lake" vs region "Blue Lake") don't collide.
+    const current = getRecentEntries().filter((e) => {
+      if (e.kind !== entry.kind) return true;
+      if (e.kind === "campsite" && entry.kind === "campsite") return e.id !== entry.id;
+      return e.name !== entry.name;
+    });
     localStorage.setItem(KEY, JSON.stringify([entry, ...current].slice(0, MAX)));
   } catch {
     // localStorage unavailable or full — fail silently


### PR DESCRIPTION
## Summary

- When a campsite suggestion (e.g. "Mungo Brush") is selected and saved to recents, selecting it again from recents now navigates to that specific campsite — not a location proximity search
- `handleRecentSelect` previously checked location (Mapbox geocoding) before campsite, so any campsite name that also matched a Mapbox place would trigger a 100km proximity search instead
- Priority order is now: **campsite** (most specific) → region → location → NL search fallback

## Root cause

`handleRecentSelect` fetches suggestions to determine routing. Mapbox returned "Mungo Brush" as a NSW place, so it was routed to `fetchLocationCampsites` — showing 50+ nearby campsites in the Hunter Valley instead of the specific Mungo Brush campsite on the NSW coast.

## Test plan

- [ ] Search "mungo brush", click the ⛺ campsite suggestion → map flies to Mungo Brush, 1 campsite shown
- [ ] Clear search, open recents, click "Mungo Brush" → same result as above (not a proximity search)
- [ ] Search "Jindabyne", click from recents → still correctly triggers proximity search (no campsite named Jindabyne)
- [ ] `npm test` → 289 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)