### PR TITLE
feat(map): colour-code pins by weather score

### DIFF
--- a/app/components/CampsitePin.tsx
+++ b/app/components/CampsitePin.tsx
@@ -32,6 +32,10 @@ export function CampsitePin({ campsite, idx, isSelected, onSelect }: CampsitePin
         style={{ width: pinW, height: pinH, filter: `drop-shadow(0 2px 6px rgba(0,0,0,${isSelected ? 0.45 : 0.28}))`, transition: "width 150ms, height 150ms" }}
         viewBox="0 0 26 28" fill="none"
       >
+        {isSelected && (
+          <path d="M13 1.5C7.2 1.5 2.5 6.2 2.5 12C2.5 18.5 9 24 13 26C17 24 23.5 18.5 23.5 12C23.5 6.2 18.8 1.5 13 1.5Z"
+            fill="none" stroke="#fff" strokeWidth="4.5" />
+        )}
         <path d="M13 1.5C7.2 1.5 2.5 6.2 2.5 12C2.5 18.5 9 24 13 26C17 24 23.5 18.5 23.5 12C23.5 6.2 18.8 1.5 13 1.5Z"
           fill={pinColor} stroke={isSelected ? CORAL : pinColor} strokeWidth={isSelected ? "2.5" : "1.5"} />
         <text x="13" y="12.5" textAnchor="middle" dominantBaseline="central"

--- a/app/components/CampsitePin.tsx
+++ b/app/components/CampsitePin.tsx
@@ -1,4 +1,5 @@
-import { FOREST_GREEN } from "@/lib/tokens";
+import { CORAL, FOREST_GREEN, TEXT_MUTED } from "@/lib/tokens";
+import { getWeatherBadge, weatherScore } from "@/lib/weatherScore";
 import type { Campsite } from "@/types/map";
 
 export type CampsitePinProps = {
@@ -15,6 +16,10 @@ export function CampsitePin({ campsite, idx, isSelected, onSelect }: CampsitePin
     .split(" – ")[0];
   const pinW = isSelected ? 34 : 26;
   const pinH = isSelected ? 37 : 28;
+  // No weather data yet (browse mode, not fetched for this viewport) → neutral colour.
+  const pinColor = campsite.weather && campsite.weather.length > 0
+    ? getWeatherBadge(weatherScore(campsite.weather)).color
+    : TEXT_MUTED;
   return (
     <div
       role="button" tabIndex={0}
@@ -28,9 +33,10 @@ export function CampsitePin({ campsite, idx, isSelected, onSelect }: CampsitePin
         viewBox="0 0 26 28" fill="none"
       >
         <path d="M13 1.5C7.2 1.5 2.5 6.2 2.5 12C2.5 18.5 9 24 13 26C17 24 23.5 18.5 23.5 12C23.5 6.2 18.8 1.5 13 1.5Z"
-          fill={isSelected ? FOREST_GREEN : "#fff"} stroke={FOREST_GREEN} strokeWidth="1.5" />
+          fill={pinColor} stroke={isSelected ? CORAL : pinColor} strokeWidth={isSelected ? "2.5" : "1.5"} />
         <text x="13" y="12.5" textAnchor="middle" dominantBaseline="central"
-          fill={isSelected ? "#fff" : FOREST_GREEN} fontSize={isSelected ? 11 : 9} fontWeight="800" fontFamily="DM Sans, sans-serif">
+          fill="#fff" stroke="rgba(0,0,0,0.35)" strokeWidth={0.6} paintOrder="stroke"
+          fontSize={isSelected ? 11 : 9} fontWeight="800" fontFamily="DM Sans, sans-serif">
           {idx + 1}
         </text>
       </svg>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -107,6 +107,7 @@ function ClusterBubble({ count, color, ariaLabel, onExpand }: ClusterBubbleProps
         height: size,
         background: color,
         fontSize: size >= 48 ? 14 : 12,
+        WebkitTextStroke: "0.6px rgba(0,0,0,0.35)",
       }}
     >
       {count}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -13,7 +13,7 @@ import BottomDrawer, {
   getDrawerHeightPx,
 } from "./BottomDrawer";
 import type { AmenityPOI, Campsite } from "@/types/map";
-import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE, SURFACE_OVERLAY, TEXT } from "@/lib/tokens";
+import { BORDER, CORAL, FOREST_GREEN, SAGE, SURFACE, SURFACE_OVERLAY, TEXT, TEXT_MUTED } from "@/lib/tokens";
 import { SEARCH_RESULTS_KEY, parseSearchResultsPayload, type SearchResultsPayload, type AISearchPayload, type AmenitySearchPayload } from "@/lib/searchResults";
 import type { ParsedIntent } from "@/lib/parseIntent";
 import { getRecentEntries, addRecentEntry, type RecentEntry } from "@/lib/recentSearches";
@@ -22,7 +22,7 @@ import { CampsitePin } from "./CampsitePin";
 import { AmenityPin, type AmenityPinMeta } from "./AmenityPin";
 import { useMapData } from "@/hooks/useMapData";
 import SearchInput, { type SearchInputHandle, type Suggestion } from "@/components/SearchInput";
-import { weatherScore } from "@/lib/weatherScore";
+import { getWeatherBadge, weatherScore } from "@/lib/weatherScore";
 
 const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_TOKEN;
 
@@ -363,6 +363,33 @@ export default function MapView() {
     }
     return map;
   }, [amenityClusters, amenityClusterInstance]);
+
+  // Pre-compute campsite cluster bubble colors keyed by cluster ID — best (highest)
+  // weather score among all leaves in the cluster, or neutral grey if none have
+  // weather data yet. Unlike amenityClusterColorMap (which samples one leaf), this
+  // scans every leaf via the cluster's exact point_count so a single great-weather
+  // site inside a large cluster is never missed.
+  const campsiteClusterColorMap = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const f of campsiteClusters) {
+      if ("cluster" in f.properties && f.properties.cluster) {
+        const clusterId = f.id as number;
+        const pointCount = (f.properties as { point_count: number }).point_count;
+        const leaves = campsiteClusterInstance.getLeaves(clusterId, pointCount);
+        let bestScore: number | null = null;
+        for (const leaf of leaves) {
+          const leafIdx = (leaf.properties as { idx: number }).idx;
+          const c = displayedCampsites[leafIdx];
+          if (c?.weather && c.weather.length > 0) {
+            const score = weatherScore(c.weather);
+            if (bestScore === null || score > bestScore) bestScore = score;
+          }
+        }
+        map.set(clusterId, bestScore === null ? TEXT_MUTED : getWeatherBadge(bestScore).color);
+      }
+    }
+    return map;
+  }, [campsiteClusters, campsiteClusterInstance, displayedCampsites]);
 
   // O(1) lookup for individual amenity POI features in the render loop.
   const amenityPoiById = useMemo(
@@ -1414,7 +1441,7 @@ export default function MapView() {
               <Marker key={`cs-cluster-${clusterId}`} longitude={fLng} latitude={fLat} anchor="center" style={{ zIndex: 2 }}>
                 <ClusterBubble
                   count={count}
-                  color={FOREST_GREEN}
+                  color={campsiteClusterColorMap.get(clusterId) ?? TEXT_MUTED}
                   ariaLabel={`${count} campsites — tap to expand`}
                   onExpand={() => {
                     try {


### PR DESCRIPTION
Closes #140

## What
- Individual campsite pins now render in green/amber/coral based on weather score (using existing `getWeatherBadge` thresholds), falling back to a neutral colour until weather data arrives (browse mode).
- Cluster bubbles use the colour of the best-scoring campsite in the cluster, or neutral if none have weather data yet.
- Selected pins get a coral outline layered over their weather-coloured fill, and pin numbers get a subtle dark halo so they stay legible across all three colours.

## Notes
- `getWeatherBadge` had zero UI callers before this — this is its first production usage.
- Verified live in-browser (Playwright): search results render coloured pins immediately, a 2-site cluster showed the best-scoring colour, and selecting a pin showed the coral outline + weather-coloured fill with drawer scroll still in sync.
- Contrast for the pin number is handled with a colour-agnostic dark halo (`stroke` + `paintOrder="stroke"`) rather than per-colour text colour choices, since amber is meaningfully lighter than green/coral and would otherwise need special-casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)